### PR TITLE
feat(研报):增加个股研报搜索功能

### DIFF
--- a/app_common.go
+++ b/app_common.go
@@ -14,6 +14,6 @@ func (a *App) LongTigerRank(date string) *[]models.LongTigerRankData {
 	return data.NewMarketNewsApi().LongTiger(date)
 }
 
-func (a *App) StockResearchReport() []any {
-	return data.NewMarketNewsApi().StockResearchReport(7)
+func (a *App) StockResearchReport(stockCode string) []any {
+	return data.NewMarketNewsApi().StockResearchReport(stockCode, 7)
 }

--- a/backend/data/market_news_api_test.go
+++ b/backend/data/market_news_api_test.go
@@ -67,7 +67,7 @@ func TestLongTiger(t *testing.T) {
 
 func TestStockResearchReport(t *testing.T) {
 	db.Init("../../data/stock.db")
-	resp := NewMarketNewsApi().StockResearchReport(7)
+	resp := NewMarketNewsApi().StockResearchReport("600584.sh", 7)
 	for _, a := range resp {
 		logger.SugaredLogger.Debugf("value: %+v", a)
 	}

--- a/frontend/src/components/StockResearchReportList.vue
+++ b/frontend/src/components/StockResearchReportList.vue
@@ -1,24 +1,27 @@
 <script setup>
 import {onBeforeMount, ref} from 'vue'
-import {StockResearchReport} from "../../wailsjs/go/main/App";
+import {GetStockList, StockResearchReport} from "../../wailsjs/go/main/App";
 import {ArrowDownOutline, CaretDown, CaretUp, PulseOutline, Refresh, RefreshCircleSharp,} from "@vicons/ionicons5";
 
 import KLineChart from "./KLineChart.vue";
 import MoneyTrend from "./moneyTrend.vue";
-import {NButton} from "naive-ui";
+import {useMessage} from "naive-ui";
 import {BrowserOpenURL} from "../../wailsjs/runtime";
 
+const message=useMessage()
 const list  = ref([])
 
-function getStockResearchReport() {
-  StockResearchReport().then(result => {
+const options =  ref([])
+
+function getStockResearchReport(value) {
+  StockResearchReport(value).then(result => {
     console.log(result)
     list.value = result
   })
 }
 
 onBeforeMount(()=>{
-  getStockResearchReport();
+  getStockResearchReport('');
 })
 
 function ratingChangeName(ratingChange){
@@ -52,9 +55,30 @@ function getmMarketCode(market,code) {
 function openWin(code) {
   BrowserOpenURL("https://pdf.dfcfw.com/pdf/H3_"+code+"_1.pdf?1749744888000.pdf")
 }
+
+function findStockList(query){
+  if (query){
+    GetStockList(query).then(result => {
+      options.value=result.map(item => {
+        return {
+          label: item.name+" - "+item.ts_code,
+          value: item.ts_code
+        }
+      })
+    })
+  }else{
+    getStockResearchReport('')
+  }
+}
+function handleSearch(value) {
+  getStockResearchReport(value)
+}
 </script>
 
 <template>
+  <n-card>
+    <n-auto-complete  :options="options" placeholder="请输入A股名称或者代码"  clearable filterable  :on-select="handleSearch" :on-update:value="findStockList"  />
+  </n-card>
   <n-table striped size="small">
     <n-thead>
       <n-tr>

--- a/frontend/wailsjs/go/main/App.d.ts
+++ b/frontend/wailsjs/go/main/App.d.ts
@@ -89,7 +89,7 @@ export function SetStockSort(arg1:number,arg2:string):Promise<void>;
 
 export function ShareAnalysis(arg1:string,arg2:string):Promise<string>;
 
-export function StockResearchReport():Promise<Array<any>>;
+export function StockResearchReport(arg1:string):Promise<Array<any>>;
 
 export function SummaryStockNews(arg1:string,arg2:any):Promise<void>;
 

--- a/frontend/wailsjs/go/main/App.js
+++ b/frontend/wailsjs/go/main/App.js
@@ -174,8 +174,8 @@ export function ShareAnalysis(arg1, arg2) {
   return window['go']['main']['App']['ShareAnalysis'](arg1, arg2);
 }
 
-export function StockResearchReport() {
-  return window['go']['main']['App']['StockResearchReport']();
+export function StockResearchReport(arg1) {
+  return window['go']['main']['App']['StockResearchReport'](arg1);
 }
 
 export function SummaryStockNews(arg1, arg2) {


### PR DESCRIPTION
feat(研报):增加个股研报搜索功能

- 修改 App.d.ts 和 App.js，为 StockResearchReport 函数添加股票代码参数
- 更新 app_common.go，将 StockResearchReport 方法改为接收股票代码参数
- 修改 market_news_api.go，实现根据股票代码查询研报的逻辑
- 更新 market_news_api_test.go，添加针对具体股票代码的测试用例
- 在前端 StockResearchReportList 组件中增加股票代码搜索功能
