### PR TITLE
fix(stock): 修复昨天因为美股逻辑导致A股关注错误

### DIFF
--- a/frontend/src/components/stock.vue
+++ b/frontend/src/components/stock.vue
@@ -434,7 +434,9 @@ function AddStock() {
   if (!stocks.value.includes(data.code)) {
     Follow(data.code).then(result => {
       if (result === "关注成功") {
-        data.code= "gb_" + data.code.replace("us", "").toLowerCase()
+        if (data.code.startsWith("us")) {
+          data.code= "gb_" + data.code.replace("us", "").toLowerCase()
+        }
         stocks.value.push(data.code)
         message.success(result)
         GetFollowList(currentGroupId.value).then(result => {


### PR DESCRIPTION
- 在关注股票时，仅当股票代码以 "us" 开头时，才将其转换为 "gb_" 前缀的格式

# Pull Request 信息

## 本次 PR 概述
请简要描述这个 Pull Request 做了什么改动。例如：
- 修复昨天因为美股逻辑导致A股关注错误


## 改动内容详细说明
### 代码修改
- 列出主要修改的文件和修改点。例如：
    - `stock.vue`：
        - 修改了函数 `AddStock` 的逻辑，在只有是美股时才修改为"gb"，不然会导致A股关注不展示
