### PR TITLE
feat(frontend): 添加股票分组拖拽排序功能

### DIFF
--- a/app.go
+++ b/app.go
@@ -1219,6 +1219,14 @@ func (a *App) GetGroupList() []data.Group {
 	return data.NewStockGroupApi(db.Dao).GetGroupList()
 }
 
+func (a *App) UpdateGroupSort(id int, newSort int) bool {
+	return data.NewStockGroupApi(db.Dao).UpdateGroupSort(id, newSort)
+}
+
+func (a *App) InitializeGroupSort() bool {
+	return data.NewStockGroupApi(db.Dao).InitializeGroupSort()
+}
+
 func (a *App) GetGroupStockList(groupId int) []data.GroupStock {
 	return data.NewStockGroupApi(db.Dao).GetGroupStockByGroupId(groupId)
 }

--- a/backend/data/stock_group_api.go
+++ b/backend/data/stock_group_api.go
@@ -39,16 +39,73 @@ func NewStockGroupApi(dao *gorm.DB) *StockGroupApi {
 }
 
 func (receiver StockGroupApi) AddGroup(group Group) bool {
-	err := receiver.dao.Where("name = ?", group.Name).FirstOrCreate(&group).Updates(&Group{
-		Name: group.Name,
-		Sort: group.Sort,
-	}).Error
+	// 检查是否已存在相同sort的组
+	var existingGroup Group
+	err := receiver.dao.Where("sort = ?", group.Sort).First(&existingGroup).Error
+
+	// 如果存在相同sort的组，则将该组及之后的所有组向后移动一位
+	if err == nil {
+		// 处理sort冲突：将相同sort值及之后的所有组向后移动一位
+		receiver.dao.Model(&Group{}).Where("sort >= ?", group.Sort).Update("sort", gorm.Expr("sort + ?", 1))
+	}
+
+	// 创建新组
+	err = receiver.dao.Create(&group).Error
 	return err == nil
 }
 func (receiver StockGroupApi) GetGroupList() []Group {
 	var groups []Group
-	receiver.dao.Find(&groups)
+	receiver.dao.Order("sort ASC").Find(&groups)
 	return groups
+}
+func (receiver StockGroupApi) UpdateGroupSort(id int, newSort int) bool {
+	// First, get the current group to check if it exists
+	var currentGroup Group
+	if err := receiver.dao.First(&currentGroup, id).Error; err != nil {
+		return false
+	}
+
+	// If the new sort is the same as current, no need to update
+	if currentGroup.Sort == newSort {
+		return true
+	}
+
+	// Get all groups ordered by sort
+	var allGroups []Group
+	receiver.dao.Order("sort ASC").Find(&allGroups)
+
+	// Adjust sort numbers to make space for the new sort value
+	if newSort > currentGroup.Sort {
+		// Moving down: decrease sort of groups between old and new position
+		receiver.dao.Model(&Group{}).Where("sort > ? AND sort <= ? AND id != ?", currentGroup.Sort, newSort, id).Update("sort", gorm.Expr("sort - ?", 1))
+	} else {
+		// Moving up: increase sort of groups between new and old position
+		receiver.dao.Model(&Group{}).Where("sort >= ? AND sort < ? AND id != ?", newSort, currentGroup.Sort, id).Update("sort", gorm.Expr("sort + ?", 1))
+	}
+
+	// Update the target group's sort
+	err := receiver.dao.Model(&Group{}).Where("id = ?", id).Update("sort", newSort).Error
+	return err == nil
+}
+
+// InitializeGroupSort initializes sort order for all groups based on created time
+func (receiver StockGroupApi) InitializeGroupSort() bool {
+	// Get all groups ordered by created time
+	var groups []Group
+	err := receiver.dao.Order("created_at ASC").Find(&groups).Error
+	if err != nil {
+		return false
+	}
+
+	// Update each group with new sort value based on their position
+	for i, group := range groups {
+		newSort := i + 1
+		err := receiver.dao.Model(&Group{}).Where("id = ?", group.ID).Update("sort", newSort).Error
+		if err != nil {
+			return false
+		}
+	}
+	return true
 }
 func (receiver StockGroupApi) GetGroupStockByGroupId(groupId int) []GroupStock {
 	var stockGroup []GroupStock

--- a/frontend/wailsjs/go/main/App.d.ts
+++ b/frontend/wailsjs/go/main/App.d.ts
@@ -88,6 +88,8 @@ export function HotTopic(arg1:number):Promise<Array<any>>;
 
 export function IndustryResearchReport(arg1:string):Promise<Array<any>>;
 
+export function InitializeGroupSort():Promise<boolean>;
+
 export function InvestCalendarTimeLine(arg1:string):Promise<Array<any>>;
 
 export function LongTigerRank(arg1:string):Promise<any>;
@@ -139,3 +141,5 @@ export function UnFollow(arg1:string):Promise<string>;
 export function UnFollowFund(arg1:string):Promise<string>;
 
 export function UpdateConfig(arg1:data.SettingConfig):Promise<string>;
+
+export function UpdateGroupSort(arg1:number,arg2:number):Promise<boolean>;

--- a/frontend/wailsjs/go/main/App.js
+++ b/frontend/wailsjs/go/main/App.js
@@ -170,6 +170,10 @@ export function IndustryResearchReport(arg1) {
   return window['go']['main']['App']['IndustryResearchReport'](arg1);
 }
 
+export function InitializeGroupSort() {
+  return window['go']['main']['App']['InitializeGroupSort']();
+}
+
 export function InvestCalendarTimeLine(arg1) {
   return window['go']['main']['App']['InvestCalendarTimeLine'](arg1);
 }
@@ -272,4 +276,8 @@ export function UnFollowFund(arg1) {
 
 export function UpdateConfig(arg1) {
   return window['go']['main']['App']['UpdateConfig'](arg1);
+}
+
+export function UpdateGroupSort(arg1, arg2) {
+  return window['go']['main']['App']['UpdateGroupSort'](arg1, arg2);
 }


### PR DESCRIPTION
# Pull Request 信息

## 本次 PR 概述
请简要描述这个 Pull Request 做了什么改动。例如：
- 在前端实现股票分组的拖拽排序功能
- 新增后端接口支持分组排序的更新
- 优化数据库操作，确保分组顺序的正确性和唯一性
- 修复了一些与分组列表相关的小问题

## 相关问题
如果这个 PR 是为了解决某个 Issue，请在此处关联对应的 Issue 编号，格式为 `Fixes #<issue-number>`。例如：
Fixes #95

## 改动内容详细说明
### 代码修改
- 列出主要修改的文件和修改点。例如：
    - `stock.vue`：
        - 加载组如果有重复组序号时，调用初始化组序号接口确保组序号唯一
        - 实现股票分组的拖拽排序功能。
        - 调整了事件注册钩子
    - `stock_group_api.go`：
        - 新增了InitializeGroupSort，初始化组序号确保组序号唯一。
        - 新增了UpdateGroupSort，支持组修改顺序
        - 修改了GetGroupList，获取组时按序号顺序获取
        - 修改了AddGroup，创建组时填的序号如果有冲突，则后移所有组

### 新增功能
如果有新增功能，请详细描述该功能的使用方法和特点。例如：
-实现股票分组的拖拽排序功能
