### PR TITLE
Potential fix for code scanning alert no. 13: Clear-text logging of sensitive information

### DIFF
--- a/backend/data/openai_stream.go
+++ b/backend/data/openai_stream.go
@@ -32,7 +32,7 @@ func (o *OpenAi) NewSummaryStockNewsStreamWithTools(userQuestion string, sysProm
 		defer func() {
 			if err := recover(); err != nil {
 				logger.SugaredLogger.Errorf("NewSummaryStockNewsStream goroutine panic: %s", err)
-				logger.SugaredLogger.Errorf("NewSummaryStockNewsStream goroutine panic config: %s", o.String())
+				logger.SugaredLogger.Errorf("NewSummaryStockNewsStream goroutine panic context: model=%s timeout=%d", o.Model, o.TimeOut)
 			}
 		}()
 		defer close(ch)
@@ -315,7 +315,7 @@ func (o *OpenAi) NewChatStream(stock, stockCode, userQuestion string, sysPromptI
 			if err := recover(); err != nil {
 				logger.SugaredLogger.Errorf("NewChatStream goroutine  panic :%s", err)
 				logger.SugaredLogger.Errorf("NewChatStream goroutine  panic  stock:%s stockCode:%s", stock, stockCode)
-				logger.SugaredLogger.Errorf("NewChatStream goroutine  panic  config:%s", o.String())
+				logger.SugaredLogger.Errorf("NewChatStream goroutine  panic  context:model=%s timeout=%d", o.Model, o.TimeOut)
 			}
 		}()
 		defer close(ch)


### PR DESCRIPTION
Potential fix for [https://github.com/ArvinLovegood/go-stock/security/code-scanning/13](https://github.com/ArvinLovegood/go-stock/security/code-scanning/13)

To fix clear-text/sensitive logging without changing behavior, remove logging of full `OpenAi` configuration objects in panic handlers and replace with minimal, non-sensitive context fields only.

Best fix in the shown code:
- In `backend/data/openai_stream.go`, update panic logs that currently include `o.String()`:
  - In `NewSummaryStockNewsStreamWithTools` panic defer, replace `... panic config: %s", o.String()` with a safe summary such as model and timeout.
  - In `NewChatStream` panic defer, replace `... panic  config:%s", o.String()` similarly.
- Do **not** log `ApiKey`, prompt, proxy, or full config blobs.
- No functionality changes: panic recovery and logging remain, only message content is sanitized.

No new methods or imports are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
