### PR TITLE
Potential fix for code scanning alert no. 12: Clear-text logging of sensitive information

### DIFF
--- a/backend/data/openai_stream.go
+++ b/backend/data/openai_stream.go
@@ -32,7 +32,7 @@ func (o *OpenAi) NewSummaryStockNewsStreamWithTools(userQuestion string, sysProm
 		defer func() {
 			if err := recover(); err != nil {
 				logger.SugaredLogger.Errorf("NewSummaryStockNewsStream goroutine panic: %s", err)
-				logger.SugaredLogger.Errorf("NewSummaryStockNewsStream goroutine panic config: %s", o.String())
+				logger.SugaredLogger.Errorf("NewSummaryStockNewsStream goroutine panic context: model=%s baseUrl=%s", o.Model, o.BaseUrl)
 			}
 		}()
 		defer close(ch)
@@ -172,7 +172,7 @@ func (o *OpenAi) NewSummaryStockNewsStream(userQuestion string, sysPromptId *int
 		defer func() {
 			if err := recover(); err != nil {
 				logger.SugaredLogger.Errorf("NewSummaryStockNewsStream goroutine  panic :%s", err)
-				logger.SugaredLogger.Errorf("NewSummaryStockNewsStream goroutine  panic  config:%s", o.String())
+				logger.SugaredLogger.Errorf("NewSummaryStockNewsStream goroutine panic context: model=%s baseUrl=%s", o.Model, o.BaseUrl)
 			}
 		}()
 		defer close(ch)


### PR DESCRIPTION
Potential fix for [https://github.com/ArvinLovegood/go-stock/security/code-scanning/12](https://github.com/ArvinLovegood/go-stock/security/code-scanning/12)

General fix: never log whole config/state objects that may carry secrets; log only a strict allowlist of non-sensitive fields (or omit config entirely) in error paths.

Best fix here (without changing behavior): in `backend/data/openai_stream.go`, replace panic log lines that include `o.String()` with a sanitized, minimal message (e.g., model/base URL only, no prompt/key/proxy/path), or simply remove the config dump. This preserves panic reporting while eliminating sensitive-data exposure risk and avoids reliance on `String()` masking.

Specific edits:
- In `NewSummaryStockNewsStreamWithTools` panic defer block: replace `... panic config: %s", o.String()` with a sanitized structured message.
- In `NewSummaryStockNewsStream` panic defer block: same replacement.

No new imports/dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
