### PR TITLE
Potential fix for code scanning alert no. 11: Clear-text logging of sensitive information

### DIFF
--- a/backend/data/openai_stream.go
+++ b/backend/data/openai_stream.go
@@ -32,7 +32,7 @@ func (o *OpenAi) NewSummaryStockNewsStreamWithTools(userQuestion string, sysProm
 		defer func() {
 			if err := recover(); err != nil {
 				logger.SugaredLogger.Errorf("NewSummaryStockNewsStream goroutine panic: %s", err)
-				logger.SugaredLogger.Errorf("NewSummaryStockNewsStream goroutine panic config: %s", o.String())
+				logger.SugaredLogger.Errorf("NewSummaryStockNewsStream goroutine panic context: model=%s timeout=%d maxTokens=%d", o.Model, o.TimeOut, o.MaxTokens)
 			}
 		}()
 		defer close(ch)


### PR DESCRIPTION
Potential fix for [https://github.com/ArvinLovegood/go-stock/security/code-scanning/11](https://github.com/ArvinLovegood/go-stock/security/code-scanning/11)

General fix: never log whole config objects that may carry secrets (API keys, tokens, proxies with credentials, etc.). Log only non-sensitive metadata or explicit redacted fields.

Best fix here (without functional change): in `backend/data/openai_stream.go`, replace the panic log line that prints `o.String()` with a sanitized, field-level log that includes only safe operational context (e.g., model, timeout, max tokens), and omits prompt/API key/base URL/proxy details.

Change region:
- `backend/data/openai_stream.go` in `NewSummaryStockNewsStreamWithTools`, inside the goroutine panic `defer` block.
- Replace:
  - `logger.SugaredLogger.Errorf("NewSummaryStockNewsStream goroutine panic config: %s", o.String())`
- With:
  - a message that logs only non-sensitive fields, e.g. model/timeout/maxTokens.

No new imports, helper methods, or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
