### PR TITLE
feat: optimize AI provider configuration and add Codex analysis

### DIFF
--- a/app.go
+++ b/app.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"go-stock/backend/agent"
 	"go-stock/backend/agent/tools"
+	"go-stock/backend/codexcli"
 	"go-stock/backend/data"
 	"go-stock/backend/db"
 	"go-stock/backend/logger"
@@ -2943,6 +2944,17 @@ func (a *App) GetAiConfigs() []*data.AIConfig {
 // UpdateAiConfigs 仅更新 AI 模型服务配置，供独立的 AI 模型服务管理页面调用
 func (a *App) UpdateAiConfigs(aiConfigs []*data.AIConfig) string {
 	return data.UpdateAiConfigsOnly(aiConfigs)
+}
+
+// RunCodexDeepAnalysis runs an explicit, read-only local Codex job. It is kept
+// separate from scheduled/provider API traffic and never silently falls back.
+func (a *App) RunCodexDeepAnalysis(question, model, effort string) map[string]any {
+	result, err := (codexcli.Runner{}).Run(context.Background(), question, model, effort)
+	if err != nil {
+		logger.SugaredLogger.Errorf("Codex deep analysis failed: %v", err)
+		return map[string]any{"ok": false, "error": err.Error()}
+	}
+	return map[string]any{"ok": true, "content": result}
 }
 
 // GetAiAssistantSession 获取 AI 助手会话消息列表，sessionId 为空时获取最新的

--- a/app.go
+++ b/app.go
@@ -5,7 +5,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/base64"
-	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"go-stock/backend/agent"
@@ -22,7 +21,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/duke-git/lancet/v2/cryptor"
 	"github.com/inconshreveable/go-update"
 	"github.com/samber/lo"
 	"golang.org/x/exp/slices"
@@ -50,6 +48,9 @@ type App struct {
 	summaryCancel      context.CancelFunc
 	agentMu            sync.Mutex
 	agentCancel        context.CancelFunc
+	codexMu            sync.Mutex
+	codexCancel        context.CancelFunc
+	codexRunID         uint64
 	stockAlertMu       sync.Mutex
 	stockAlertLastSent map[string]time.Time
 	priceAtAlertReset  map[string]float64
@@ -224,23 +225,9 @@ func (a *App) QuitApp() {
 func (a *App) CheckSponsorCode(sponsorCode string) map[string]any {
 	sponsorCode = strutil.Trim(sponsorCode)
 	if sponsorCode != "" {
-		encrypted, err := hex.DecodeString(sponsorCode)
+		_, err := data.DecodeSponsorInfo(sponsorCode, BuildKey)
 		if err != nil {
-			return map[string]any{
-				"code": 0,
-				"msg":  "赞助码格式错误,请输入正确的赞助码!",
-			}
-		}
-		key, err := hex.DecodeString(BuildKey)
-		if err != nil {
-			logger.SugaredLogger.Error(err.Error())
-			return map[string]any{
-				"code": 0,
-				"msg":  "版本错误，不支持赞助码!",
-			}
-		}
-		decrypt := cryptor.AesEcbDecrypt(encrypted, key)
-		if decrypt == nil || len(decrypt) == 0 {
+			logger.SugaredLogger.Warnf("赞助码校验失败: %v", err)
 			return map[string]any{
 				"code": 0,
 				"msg":  "赞助码错误，请输入正确的赞助码!",
@@ -267,22 +254,12 @@ func (a *App) CheckSponsorCode(sponsorCode string) map[string]any {
 func (a *App) CheckUpdate(flag int) {
 	sponsorCode := strutil.Trim(a.GetConfig().SponsorCode)
 	if sponsorCode != "" {
-		encrypted, err := hex.DecodeString(sponsorCode)
+		info, err := data.DecodeSponsorInfo(sponsorCode, BuildKey)
 		if err != nil {
-			logger.SugaredLogger.Error(err.Error())
+			logger.SugaredLogger.Warnf("跳过赞助信息解密: %v", err)
 			return
 		}
-		key, err := hex.DecodeString(BuildKey)
-		if err != nil {
-			logger.SugaredLogger.Error(err.Error())
-			return
-		}
-		decrypt := string(cryptor.AesEcbDecrypt(encrypted, key))
-		err = json.Unmarshal([]byte(decrypt), &a.SponsorInfo)
-		if err != nil {
-			logger.SugaredLogger.Error(err.Error())
-			return
-		}
+		a.SponsorInfo = info
 	}
 
 	updateChannel := a.GetConfig().UpdateChannel
@@ -507,26 +484,16 @@ func (a *App) isVip(sponsorCode string, downloadUrl string, releaseVersion *mode
 	vipLevel := "0"
 	sponsorCode = strutil.Trim(a.GetConfig().SponsorCode)
 	if sponsorCode != "" {
-		encrypted, err := hex.DecodeString(sponsorCode)
+		info, err := data.DecodeSponsorInfo(sponsorCode, BuildKey)
 		if err != nil {
-			logger.SugaredLogger.Error(err.Error())
+			logger.SugaredLogger.Warnf("赞助信息解密失败: %v", err)
 			return "", "0", false
 		}
-		key, err := hex.DecodeString(BuildKey)
-		if err != nil {
-			logger.SugaredLogger.Error(err.Error())
-			return "", "0", false
-		}
-		decrypt := string(cryptor.AesEcbDecrypt(encrypted, key))
-		err = json.Unmarshal([]byte(decrypt), &a.SponsorInfo)
-		if err != nil {
-			logger.SugaredLogger.Error(err.Error())
-			return "", "0", false
-		}
-		vipLevel = a.SponsorInfo["vipLevel"].(string)
-		vipStartTime, err := time.ParseInLocation("2006-01-02 15:04:05", a.SponsorInfo["vipStartTime"].(string), time.Local)
-		vipEndTime, err := time.ParseInLocation("2006-01-02 15:04:05", a.SponsorInfo["vipEndTime"].(string), time.Local)
-		vipAuthTime, err := time.ParseInLocation("2006-01-02 15:04:05", a.SponsorInfo["vipAuthTime"].(string), time.Local)
+		a.SponsorInfo = info
+		vipLevel = convertor.ToString(a.SponsorInfo["vipLevel"])
+		vipStartTime, err := time.ParseInLocation("2006-01-02 15:04:05", convertor.ToString(a.SponsorInfo["vipStartTime"]), time.Local)
+		vipEndTime, err := time.ParseInLocation("2006-01-02 15:04:05", convertor.ToString(a.SponsorInfo["vipEndTime"]), time.Local)
+		vipAuthTime, err := time.ParseInLocation("2006-01-02 15:04:05", convertor.ToString(a.SponsorInfo["vipAuthTime"]), time.Local)
 		if err != nil {
 			logger.SugaredLogger.Error(err.Error())
 			return "", vipLevel, false
@@ -2949,12 +2916,39 @@ func (a *App) UpdateAiConfigs(aiConfigs []*data.AIConfig) string {
 // RunCodexDeepAnalysis runs an explicit, read-only local Codex job. It is kept
 // separate from scheduled/provider API traffic and never silently falls back.
 func (a *App) RunCodexDeepAnalysis(question, model, effort string) map[string]any {
-	result, err := (codexcli.Runner{}).Run(context.Background(), question, model, effort)
+	ctx, cancel := context.WithCancel(context.Background())
+	a.codexMu.Lock()
+	if a.codexCancel != nil {
+		a.codexCancel()
+	}
+	a.codexRunID++
+	runID := a.codexRunID
+	a.codexCancel = cancel
+	a.codexMu.Unlock()
+	defer cancel()
+	defer func() {
+		a.codexMu.Lock()
+		if a.codexRunID == runID {
+			a.codexCancel = nil
+		}
+		a.codexMu.Unlock()
+	}()
+
+	result, err := (codexcli.Runner{}).Run(ctx, question, model, effort)
 	if err != nil {
 		logger.SugaredLogger.Errorf("Codex deep analysis failed: %v", err)
 		return map[string]any{"ok": false, "error": err.Error()}
 	}
 	return map[string]any{"ok": true, "content": result}
+}
+
+func (a *App) AbortCodexDeepAnalysis() {
+	a.codexMu.Lock()
+	defer a.codexMu.Unlock()
+	if a.codexCancel != nil {
+		a.codexCancel()
+		a.codexCancel = nil
+	}
 }
 
 // GetAiAssistantSession 获取 AI 助手会话消息列表，sessionId 为空时获取最新的

--- a/backend/agent/agent.go
+++ b/backend/agent/agent.go
@@ -140,7 +140,7 @@ func createReactAgent(ctx context.Context, chatModel model.ToolCallingChatModel,
 		ToolsConfig:      aiTools,
 		MaxStep:          maxStep,
 		MessageRewriter: func(ctx context.Context, input []*schema.Message) []*schema.Message {
-			maxTokens := getMaxInputTokens(aiConfig.MaxTokens)
+			maxTokens := aiConfig.EffectiveMaxInputTokens()
 			return compressMessages(input, maxTokens)
 		},
 		StreamToolCallChecker: func(ctx context.Context, modelOutput *schema.StreamReader[*schema.Message]) (bool, error) {

--- a/backend/agent/agent_api.go
+++ b/backend/agent/agent_api.go
@@ -158,7 +158,7 @@ func (receiver StockAiAgent) ChatWithContext(ctx context.Context, question strin
 		})
 		maxInputTokens := 0
 		if aiConfig != nil {
-			maxInputTokens = getMaxInputTokens(aiConfig.MaxTokens)
+			maxInputTokens = aiConfig.EffectiveMaxInputTokens()
 		}
 
 		sysPromptTokens := estimateTokens(sysPrompt)

--- a/backend/agent/chat_model_factory.go
+++ b/backend/agent/chat_model_factory.go
@@ -117,11 +117,14 @@ func createChatModel(ctx context.Context, aiConfig data.AIConfig) (model.ToolCal
 	baseURL := normalizeChatModelBaseURL(aiConfig.BaseUrl)
 	baseLower := strings.ToLower(baseURL)
 	temperature := float32(aiConfig.Temperature)
-	timeout := time.Duration(aiConfig.TimeOut) * time.Second
+	if effective := aiConfig.EffectiveTemperature(); effective != nil {
+		temperature = float32(*effective)
+	}
+	timeout := time.Duration(aiConfig.EffectiveTimeout()) * time.Second
 	if timeout <= 0 {
 		timeout = 300 * time.Second
 	}
-	maxTok := aiConfig.MaxTokens
+	maxTok := aiConfig.EffectiveMaxOutputTokens()
 	if maxTok <= 0 {
 		maxTok = 4096
 	}
@@ -263,7 +266,9 @@ func createChatModel(ctx context.Context, aiConfig data.AIConfig) (model.ToolCal
 
 	default:
 		extraFields := map[string]any{}
-		if aiConfig.Thinking {
+		if aiConfig.Thinking && aiConfig.EffectiveReasoningEffort() != "" {
+			extraFields["reasoning_effort"] = aiConfig.EffectiveReasoningEffort()
+		} else if aiConfig.Thinking {
 			logger.SugaredLogger.Warnf("generic OpenAI-compatible agent model %q ignores thinking option to keep request parameters standard", aiConfig.ModelName)
 		}
 		cfg := &einoopenai.ChatModelConfig{
@@ -272,8 +277,10 @@ func createChatModel(ctx context.Context, aiConfig data.AIConfig) (model.ToolCal
 			APIKey:      aiConfig.ApiKey,
 			Timeout:     timeout,
 			MaxTokens:   &maxTok,
-			Temperature: &temperature,
 			ExtraFields: extraFields,
+		}
+		if aiConfig.EffectiveTemperature() != nil {
+			cfg.Temperature = &temperature
 		}
 		if proxyClient := buildProxyHTTPClient(timeout); proxyClient != nil {
 			cfg.HTTPClient = proxyClient

--- a/backend/agent/chat_model_factory.go
+++ b/backend/agent/chat_model_factory.go
@@ -276,8 +276,12 @@ func createChatModel(ctx context.Context, aiConfig data.AIConfig) (model.ToolCal
 			Model:       aiConfig.ModelName,
 			APIKey:      aiConfig.ApiKey,
 			Timeout:     timeout,
-			MaxTokens:   &maxTok,
 			ExtraFields: extraFields,
+		}
+		if aiConfig.Family() == data.ModelFamilyGPT5 || aiConfig.Family() == data.ModelFamilyGrok {
+			extraFields["max_completion_tokens"] = maxTok
+		} else {
+			cfg.MaxTokens = &maxTok
 		}
 		if aiConfig.EffectiveTemperature() != nil {
 			cfg.Temperature = &temperature

--- a/backend/agent/chat_model_factory_policy_test.go
+++ b/backend/agent/chat_model_factory_policy_test.go
@@ -1,0 +1,98 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"go-stock/backend/data"
+	"go-stock/backend/db"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/cloudwego/eino/schema"
+)
+
+func TestGPTAgentRequestUsesModernReasoningParameters(t *testing.T) {
+	requestBody := make(chan map[string]interface{}, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]interface{}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Errorf("decode request: %v", err)
+		}
+		requestBody <- body
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"chatcmpl-test","object":"chat.completion","model":"gpt-5.6-sol","choices":[{"index":0,"message":{"role":"assistant","content":"OK"},"finish_reason":"stop"}]}`))
+	}))
+	defer server.Close()
+
+	db.Init("file:agent-policy-test?mode=memory&cache=shared")
+	chatModel, err := createChatModel(context.Background(), data.AIConfig{
+		BaseUrl:         server.URL + "/v1",
+		ApiKey:          "test-key",
+		ModelName:       "gpt-5.6-sol",
+		Thinking:        true,
+		MaxOutputTokens: 16384,
+		ReasoningEffort: "medium",
+		TemperatureOpt:  nil,
+		TimeOut:         30,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := chatModel.Generate(context.Background(), []*schema.Message{schema.UserMessage("hello")}); err != nil {
+		t.Fatal(err)
+	}
+	body := <-requestBody
+	if body["reasoning_effort"] != "medium" {
+		t.Fatalf("reasoning_effort = %#v", body["reasoning_effort"])
+	}
+	if body["max_completion_tokens"] != float64(16384) {
+		t.Fatalf("max_completion_tokens = %#v", body["max_completion_tokens"])
+	}
+	if _, ok := body["max_tokens"]; ok {
+		t.Fatalf("modern GPT request unexpectedly contains max_tokens: %#v", body["max_tokens"])
+	}
+	if _, ok := body["temperature"]; ok {
+		t.Fatalf("modern GPT request unexpectedly contains temperature: %#v", body["temperature"])
+	}
+}
+
+func TestGrokAgentRequestUsesModernReasoningParameters(t *testing.T) {
+	requestBody := make(chan map[string]interface{}, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]interface{}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Errorf("decode request: %v", err)
+		}
+		requestBody <- body
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"chatcmpl-test","object":"chat.completion","model":"grok-4.5","choices":[{"index":0,"message":{"role":"assistant","content":"OK"},"finish_reason":"stop"}]}`))
+	}))
+	defer server.Close()
+
+	db.Init("file:agent-grok-policy-test?mode=memory&cache=shared")
+	chatModel, err := createChatModel(context.Background(), data.AIConfig{
+		BaseUrl:         server.URL + "/v1",
+		ApiKey:          "test-key",
+		ModelName:       "grok-4.5",
+		Thinking:        true,
+		ReasoningEffort: "medium",
+		TimeOut:         30,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := chatModel.Generate(context.Background(), []*schema.Message{schema.UserMessage("hello")}); err != nil {
+		t.Fatal(err)
+	}
+	body := <-requestBody
+	if body["reasoning_effort"] != "medium" || body["max_completion_tokens"] != float64(8192) {
+		t.Fatalf("unexpected Grok policy body: %#v", body)
+	}
+	if body["temperature"] != 0.2 {
+		t.Fatalf("temperature = %#v, want 0.2", body["temperature"])
+	}
+	if _, ok := body["max_tokens"]; ok {
+		t.Fatalf("modern Grok request unexpectedly contains max_tokens: %#v", body["max_tokens"])
+	}
+}

--- a/backend/codexcli/runner.go
+++ b/backend/codexcli/runner.go
@@ -9,13 +9,12 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
-	"sync"
 	"time"
 )
 
 const defaultTimeout = 10 * time.Minute
 
-var runMu sync.Mutex
+var runSlot = make(chan struct{}, 1)
 
 type Runner struct {
 	Executable string
@@ -50,10 +49,16 @@ func (r Runner) Run(ctx context.Context, prompt, model, effort string) (string, 
 		r.SourceHome = filepath.Join(home, ".codex")
 	}
 
-	// The local CLI is intentionally serialized: deep analysis is expensive and
-	// must never compete with scheduled direct-API jobs.
-	runMu.Lock()
-	defer runMu.Unlock()
+	runCtx, cancel := context.WithTimeout(ctx, r.Timeout)
+	defer cancel()
+	// The local CLI is intentionally serialized. Acquiring the slot is
+	// context-aware so queueing consumes the same timeout budget as execution.
+	select {
+	case runSlot <- struct{}{}:
+		defer func() { <-runSlot }()
+	case <-runCtx.Done():
+		return "", codexContextError(runCtx.Err(), r.Timeout, "while waiting for the execution slot")
+	}
 
 	runHome, err := os.MkdirTemp("", "go-stock-codex-")
 	if err != nil {
@@ -70,8 +75,6 @@ func (r Runner) Run(ctx context.Context, prompt, model, effort string) (string, 
 	}
 
 	outputPath := filepath.Join(runHome, "last-message.txt")
-	runCtx, cancel := context.WithTimeout(ctx, r.Timeout)
-	defer cancel()
 	cmd := exec.CommandContext(runCtx, r.Executable,
 		"exec", "--ephemeral", "--sandbox", "read-only", "--skip-git-repo-check",
 		"--model", model, "-c", fmt.Sprintf("model_reasoning_effort=%q", effort),
@@ -80,7 +83,7 @@ func (r Runner) Run(ctx context.Context, prompt, model, effort string) (string, 
 	cmd.Env = isolatedEnv(runHome)
 	combined, err := cmd.CombinedOutput()
 	if runCtx.Err() != nil {
-		return "", fmt.Errorf("Codex deep analysis timed out after %s", r.Timeout)
+		return "", codexContextError(runCtx.Err(), r.Timeout, "during execution")
 	}
 	if err != nil {
 		return "", fmt.Errorf("codex exec failed: %w: %s", err, truncate(string(combined), 1200))
@@ -93,6 +96,13 @@ func (r Runner) Run(ctx context.Context, prompt, model, effort string) (string, 
 		return "", errors.New("codex exec returned an empty result")
 	}
 	return strings.TrimSpace(string(answer)), nil
+}
+
+func codexContextError(err error, timeout time.Duration, phase string) error {
+	if errors.Is(err, context.DeadlineExceeded) {
+		return fmt.Errorf("Codex deep analysis timed out after %s %s", timeout, phase)
+	}
+	return fmt.Errorf("Codex deep analysis cancelled %s: %w", phase, err)
 }
 
 func copyFile(src, dst string, mode os.FileMode) error {
@@ -114,7 +124,7 @@ func copyFile(src, dst string, mode os.FileMode) error {
 
 func isolatedEnv(codexHome string) []string {
 	allowed := []string{"PATH", "TMPDIR", "LANG", "LC_ALL", "SSL_CERT_FILE", "SSL_CERT_DIR"}
-	env := []string{"CODEX_HOME=" + codexHome, "HOME=" + filepath.Dir(codexHome)}
+	env := []string{"CODEX_HOME=" + codexHome}
 	for _, key := range allowed {
 		if value, ok := os.LookupEnv(key); ok {
 			env = append(env, key+"="+value)

--- a/backend/codexcli/runner.go
+++ b/backend/codexcli/runner.go
@@ -1,0 +1,132 @@
+package codexcli
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+)
+
+const defaultTimeout = 10 * time.Minute
+
+var runMu sync.Mutex
+
+type Runner struct {
+	Executable string
+	SourceHome string
+	Timeout    time.Duration
+}
+
+func (r Runner) Run(ctx context.Context, prompt, model, effort string) (string, error) {
+	prompt = strings.TrimSpace(prompt)
+	if prompt == "" {
+		return "", errors.New("prompt is empty")
+	}
+	if strings.TrimSpace(model) == "" {
+		model = "gpt-5.6-sol"
+	}
+	switch effort {
+	case "low", "medium", "high", "xhigh":
+	default:
+		effort = "medium"
+	}
+	if r.Executable == "" {
+		r.Executable = "codex"
+	}
+	if r.Timeout <= 0 {
+		r.Timeout = defaultTimeout
+	}
+	if r.SourceHome == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", fmt.Errorf("resolve user home: %w", err)
+		}
+		r.SourceHome = filepath.Join(home, ".codex")
+	}
+
+	// The local CLI is intentionally serialized: deep analysis is expensive and
+	// must never compete with scheduled direct-API jobs.
+	runMu.Lock()
+	defer runMu.Unlock()
+
+	runHome, err := os.MkdirTemp("", "go-stock-codex-")
+	if err != nil {
+		return "", fmt.Errorf("create isolated CODEX_HOME: %w", err)
+	}
+	defer os.RemoveAll(runHome)
+	for _, name := range []string{"auth.json", "config.toml"} {
+		src := filepath.Join(r.SourceHome, name)
+		if _, statErr := os.Stat(src); statErr == nil {
+			if err := copyFile(src, filepath.Join(runHome, name), 0600); err != nil {
+				return "", fmt.Errorf("copy Codex %s: %w", name, err)
+			}
+		}
+	}
+
+	outputPath := filepath.Join(runHome, "last-message.txt")
+	runCtx, cancel := context.WithTimeout(ctx, r.Timeout)
+	defer cancel()
+	cmd := exec.CommandContext(runCtx, r.Executable,
+		"exec", "--ephemeral", "--sandbox", "read-only", "--skip-git-repo-check",
+		"--model", model, "-c", fmt.Sprintf("model_reasoning_effort=%q", effort),
+		"--output-last-message", outputPath, "-")
+	cmd.Stdin = strings.NewReader(prompt)
+	cmd.Env = isolatedEnv(runHome)
+	combined, err := cmd.CombinedOutput()
+	if runCtx.Err() != nil {
+		return "", fmt.Errorf("Codex deep analysis timed out after %s", r.Timeout)
+	}
+	if err != nil {
+		return "", fmt.Errorf("codex exec failed: %w: %s", err, truncate(string(combined), 1200))
+	}
+	answer, err := os.ReadFile(outputPath)
+	if err != nil {
+		return "", fmt.Errorf("read Codex result: %w", err)
+	}
+	if strings.TrimSpace(string(answer)) == "" {
+		return "", errors.New("codex exec returned an empty result")
+	}
+	return strings.TrimSpace(string(answer)), nil
+}
+
+func copyFile(src, dst string, mode os.FileMode) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+	out, err := os.OpenFile(dst, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, mode)
+	if err != nil {
+		return err
+	}
+	if _, err = io.Copy(out, in); err != nil {
+		out.Close()
+		return err
+	}
+	return out.Close()
+}
+
+func isolatedEnv(codexHome string) []string {
+	allowed := []string{"PATH", "TMPDIR", "LANG", "LC_ALL", "SSL_CERT_FILE", "SSL_CERT_DIR"}
+	env := []string{"CODEX_HOME=" + codexHome, "HOME=" + filepath.Dir(codexHome)}
+	for _, key := range allowed {
+		if value, ok := os.LookupEnv(key); ok {
+			env = append(env, key+"="+value)
+		}
+	}
+	return env
+}
+
+func truncate(s string, max int) string {
+	s = strings.TrimSpace(s)
+	if len(s) <= max {
+		return s
+	}
+	return s[:max] + "..."
+}

--- a/backend/codexcli/runner_test.go
+++ b/backend/codexcli/runner_test.go
@@ -1,0 +1,63 @@
+package codexcli
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestRunnerUsesIsolatedReadOnlyCodexExec(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell fixture")
+	}
+	fixture := t.TempDir()
+	sourceHome := filepath.Join(fixture, "source")
+	if err := os.Mkdir(sourceHome, 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(sourceHome, "auth.json"), []byte("{}"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	fake := filepath.Join(fixture, "codex")
+	script := `#!/bin/sh
+set -eu
+test "$1" = "exec"
+case " $* " in *" --sandbox read-only "*) ;; *) exit 21;; esac
+case " $* " in *" --ephemeral "*) ;; *) exit 22;; esac
+test -f "$CODEX_HOME/auth.json"
+while [ "$#" -gt 0 ]; do
+  if [ "$1" = "--output-last-message" ]; then shift; output="$1"; fi
+  shift
+done
+prompt=$(cat)
+printf 'result:%s' "$prompt" > "$output"
+`
+	if err := os.WriteFile(fake, []byte(script), 0700); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := (Runner{Executable: fake, SourceHome: sourceHome, Timeout: time.Second}).Run(context.Background(), "analyze", "gpt-5.6-sol", "medium")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(got, "result:analyze") {
+		t.Fatalf("result = %q", got)
+	}
+}
+
+func TestRunnerIntegration(t *testing.T) {
+	if os.Getenv("CODEX_INTEGRATION") != "1" {
+		t.Skip("set CODEX_INTEGRATION=1 to call the installed Codex CLI")
+	}
+	got, err := (Runner{Timeout: 10 * time.Minute}).Run(context.Background(), "Reply only OK", "gpt-5.6-sol", "medium")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.TrimSpace(got) != "OK" {
+		t.Fatalf("result = %q, want OK", got)
+	}
+}

--- a/backend/codexcli/runner_test.go
+++ b/backend/codexcli/runner_test.go
@@ -61,3 +61,49 @@ func TestRunnerIntegration(t *testing.T) {
 		t.Fatalf("result = %q, want OK", got)
 	}
 }
+
+func TestRunnerCanBeCancelled(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell fixture")
+	}
+	fixture := t.TempDir()
+	fake := filepath.Join(fixture, "codex")
+	if err := os.WriteFile(fake, []byte("#!/bin/sh\nexec sleep 30\n"), 0700); err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		cancel()
+	}()
+	_, err := (Runner{Executable: fake, SourceHome: fixture, Timeout: time.Minute}).Run(ctx, "analyze", "gpt-5.6-sol", "medium")
+	if err == nil || !strings.Contains(strings.ToLower(err.Error()), "cancel") {
+		t.Fatalf("error = %v, want cancellation", err)
+	}
+}
+
+func TestRunnerQueueWaitCountsTowardTimeout(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell fixture")
+	}
+	fixture := t.TempDir()
+	fake := filepath.Join(fixture, "codex")
+	if err := os.WriteFile(fake, []byte("#!/bin/sh\nexec sleep 1\n"), 0700); err != nil {
+		t.Fatal(err)
+	}
+	firstDone := make(chan struct{})
+	go func() {
+		defer close(firstDone)
+		_, _ = (Runner{Executable: fake, SourceHome: fixture, Timeout: 2 * time.Second}).Run(context.Background(), "first", "gpt-5.6-sol", "medium")
+	}()
+	time.Sleep(75 * time.Millisecond)
+	started := time.Now()
+	_, err := (Runner{Executable: fake, SourceHome: fixture, Timeout: 75 * time.Millisecond}).Run(context.Background(), "second", "gpt-5.6-sol", "medium")
+	if err == nil || !strings.Contains(strings.ToLower(err.Error()), "timed out") {
+		t.Fatalf("error = %v, want queue timeout", err)
+	}
+	if elapsed := time.Since(started); elapsed > 500*time.Millisecond {
+		t.Fatalf("queue timeout took %s", elapsed)
+	}
+	<-firstDone
+}

--- a/backend/data/ai_config_migration_test.go
+++ b/backend/data/ai_config_migration_test.go
@@ -1,0 +1,49 @@
+package data
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/glebarez/sqlite"
+	"gorm.io/gorm"
+)
+
+func TestAIConfigAutoMigratePreservesLegacyRowsAndAddsProviderPolicyColumns(t *testing.T) {
+	dsn := fmt.Sprintf("file:ai-config-migration-%s?mode=memory&cache=shared", t.Name())
+	database, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	legacySchema := `CREATE TABLE ai_config (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        name TEXT, base_url TEXT, api_key TEXT, model_name TEXT,
+        max_tokens INTEGER, temperature REAL, time_out INTEGER,
+        http_proxy TEXT, http_proxy_enabled numeric, session_id TEXT, thinking numeric
+    )`
+	if err := database.Exec(legacySchema).Error; err != nil {
+		t.Fatal(err)
+	}
+	if err := database.Exec(`INSERT INTO ai_config
+        (name, base_url, api_key, model_name, max_tokens, temperature, time_out, thinking)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?)`, "legacy-gpt", "http://example.test/v1", "secret", "gpt-5.6-sol", 81920, 0.1, 6000, true).Error; err != nil {
+		t.Fatal(err)
+	}
+	if err := database.AutoMigrate(&AIConfig{}); err != nil {
+		t.Fatal(err)
+	}
+	for _, column := range []string{"provider", "max_input_tokens", "max_output_tokens", "temperature_opt", "reasoning_effort"} {
+		if !database.Migrator().HasColumn(&AIConfig{}, column) {
+			t.Fatalf("migration did not add column %q", column)
+		}
+	}
+	var got AIConfig
+	if err := database.First(&got).Error; err != nil {
+		t.Fatal(err)
+	}
+	if got.Name != "legacy-gpt" || got.ApiKey != "secret" || got.MaxTokens != 81920 {
+		t.Fatalf("legacy row was not preserved: %+v", got)
+	}
+	if got.EffectiveMaxInputTokens() != 96000 || got.EffectiveMaxOutputTokens() != 16384 {
+		t.Fatalf("legacy row did not receive effective defaults: input=%d output=%d", got.EffectiveMaxInputTokens(), got.EffectiveMaxOutputTokens())
+	}
+}

--- a/backend/data/ai_config_policy.go
+++ b/backend/data/ai_config_policy.go
@@ -21,12 +21,11 @@ const (
 )
 
 func (c AIConfig) Family() ModelFamily {
-	provider := strings.ToLower(strings.TrimSpace(c.Provider))
 	model := strings.ToLower(strings.TrimSpace(c.ModelName))
-	if provider == AIProviderOpenAI || strings.HasPrefix(model, "gpt-5") {
+	if strings.HasPrefix(model, "gpt-5") {
 		return ModelFamilyGPT5
 	}
-	if provider == AIProviderXAI || strings.HasPrefix(model, "grok-") {
+	if strings.HasPrefix(model, "grok-4.5") {
 		return ModelFamilyGrok
 	}
 	return ModelFamilyGeneric

--- a/backend/data/ai_config_policy.go
+++ b/backend/data/ai_config_policy.go
@@ -1,0 +1,149 @@
+package data
+
+import "strings"
+
+const (
+	AIProviderAuto    = "auto"
+	AIProviderOpenAI  = "openai"
+	AIProviderXAI     = "xai"
+	AIProviderGeneric = "openai_compatible"
+)
+
+// ModelFamily is deliberately small: it captures only parameter semantics that
+// differ at the OpenAI-compatible boundary. Provider-specific SDK routing stays
+// in backend/agent/chat_model_factory.go.
+type ModelFamily string
+
+const (
+	ModelFamilyGeneric ModelFamily = "generic"
+	ModelFamilyGPT5    ModelFamily = "gpt5"
+	ModelFamilyGrok    ModelFamily = "grok"
+)
+
+func (c AIConfig) Family() ModelFamily {
+	provider := strings.ToLower(strings.TrimSpace(c.Provider))
+	model := strings.ToLower(strings.TrimSpace(c.ModelName))
+	if provider == AIProviderOpenAI || strings.HasPrefix(model, "gpt-5") {
+		return ModelFamilyGPT5
+	}
+	if provider == AIProviderXAI || strings.HasPrefix(model, "grok-") {
+		return ModelFamilyGrok
+	}
+	return ModelFamilyGeneric
+}
+
+func (c AIConfig) EffectiveMaxInputTokens() int {
+	if c.MaxInputTokens > 0 {
+		return c.MaxInputTokens
+	}
+	switch c.Family() {
+	case ModelFamilyGPT5, ModelFamilyGrok:
+		return 96000
+	default:
+		if c.MaxTokens <= 0 {
+			return 120000
+		}
+		available := int(float64(c.MaxTokens) * 0.85)
+		if available -= 20000; available >= 4000 {
+			return available
+		}
+		return 4000
+	}
+}
+
+func (c AIConfig) EffectiveMaxOutputTokens() int {
+	if c.MaxOutputTokens > 0 {
+		return c.MaxOutputTokens
+	}
+	switch c.Family() {
+	case ModelFamilyGPT5:
+		return 16384
+	case ModelFamilyGrok:
+		return 8192
+	default:
+		if c.MaxTokens > 0 {
+			return c.MaxTokens
+		}
+		return 4096
+	}
+}
+
+func (c AIConfig) EffectiveReasoningEffort() string {
+	effort := strings.ToLower(strings.TrimSpace(c.ReasoningEffort))
+	switch effort {
+	case "none", "minimal", "low", "medium", "high", "xhigh":
+		return effort
+	}
+	if c.Family() == ModelFamilyGPT5 || c.Family() == ModelFamilyGrok {
+		return "medium"
+	}
+	return ""
+}
+
+// EffectiveTemperature returns nil when the parameter should be omitted. GPT-5
+// reasoning models are most predictable when sampling is left to the provider.
+func (c AIConfig) EffectiveTemperature() *float64 {
+	if c.TemperatureOpt != nil {
+		return c.TemperatureOpt
+	}
+	switch c.Family() {
+	case ModelFamilyGPT5:
+		return nil
+	case ModelFamilyGrok:
+		v := 0.2
+		return &v
+	default:
+		if c.Temperature <= 0 {
+			return nil
+		}
+		v := c.Temperature
+		return &v
+	}
+}
+
+func (c AIConfig) EffectiveTimeout() int {
+	if c.TimeOut > 0 && c.TimeOut != 6000 {
+		return c.TimeOut
+	}
+	if c.Family() == ModelFamilyGPT5 {
+		return 900
+	}
+	if c.Family() == ModelFamilyGrok {
+		return 600
+	}
+	if c.TimeOut > 0 {
+		return c.TimeOut
+	}
+	return 300
+}
+
+// BuildOpenAICompatibleRequest centralizes request parameter semantics for the
+// direct streaming path, avoiding drift between plain chat and tool calls.
+func BuildOpenAICompatibleRequest(c AIConfig, messages []map[string]interface{}, tools []Tool, stream, reasoning bool) map[string]interface{} {
+	body := map[string]interface{}{
+		"model":    c.ModelName,
+		"stream":   stream,
+		"messages": messages,
+	}
+	if len(tools) > 0 {
+		body["tools"] = tools
+	}
+	if temp := c.EffectiveTemperature(); temp != nil {
+		body["temperature"] = *temp
+	}
+	if out := c.EffectiveMaxOutputTokens(); out > 0 {
+		if c.Family() == ModelFamilyGPT5 || c.Family() == ModelFamilyGrok {
+			body["max_completion_tokens"] = out
+		} else {
+			body["max_tokens"] = out
+		}
+	}
+	if reasoning {
+		if effort := c.EffectiveReasoningEffort(); effort != "" {
+			body["reasoning_effort"] = effort
+		} else if c.Thinking {
+			body["thinking"] = map[string]any{"type": "enabled"}
+		}
+	}
+	return body
+}

--- a/backend/data/ai_config_policy_test.go
+++ b/backend/data/ai_config_policy_test.go
@@ -1,0 +1,115 @@
+package data
+
+import "testing"
+
+func TestAIConfigEffectiveBudgetsForModernModels(t *testing.T) {
+	tests := []struct {
+		model      string
+		wantInput  int
+		wantOutput int
+		wantEffort string
+		wantTemp   *float64
+	}{
+		{model: "gpt-5.6-sol", wantInput: 96000, wantOutput: 16384, wantEffort: "medium", wantTemp: nil},
+		{model: "grok-4.5", wantInput: 96000, wantOutput: 8192, wantEffort: "medium", wantTemp: float64Ptr(0.2)},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.model, func(t *testing.T) {
+			cfg := AIConfig{ModelName: tt.model, MaxTokens: 81920, Temperature: 0.1, Thinking: true}
+			if got := cfg.EffectiveMaxInputTokens(); got != tt.wantInput {
+				t.Fatalf("input budget = %d, want %d", got, tt.wantInput)
+			}
+			if got := cfg.EffectiveMaxOutputTokens(); got != tt.wantOutput {
+				t.Fatalf("output budget = %d, want %d", got, tt.wantOutput)
+			}
+			if got := cfg.EffectiveReasoningEffort(); got != tt.wantEffort {
+				t.Fatalf("reasoning effort = %q, want %q", got, tt.wantEffort)
+			}
+			wantTimeout := 900
+			if tt.model == "grok-4.5" {
+				wantTimeout = 600
+			}
+			if got := cfg.EffectiveTimeout(); got != wantTimeout {
+				t.Fatalf("timeout = %d, want %d", got, wantTimeout)
+			}
+			gotTemp := cfg.EffectiveTemperature()
+			if tt.wantTemp == nil {
+				if gotTemp != nil {
+					t.Fatalf("temperature = %v, want omitted", *gotTemp)
+				}
+			} else if gotTemp == nil || *gotTemp != *tt.wantTemp {
+				t.Fatalf("temperature = %v, want %v", gotTemp, *tt.wantTemp)
+			}
+		})
+	}
+}
+
+func TestAIConfigLegacyGenericCompatibility(t *testing.T) {
+	cfg := AIConfig{ModelName: "deepseek-chat", MaxTokens: 8192, Temperature: 0.1, TimeOut: 300}
+	if got := cfg.EffectiveMaxInputTokens(); got != 4000 {
+		t.Fatalf("legacy input budget = %d, want 4000", got)
+	}
+	if got := cfg.EffectiveMaxOutputTokens(); got != 8192 {
+		t.Fatalf("legacy output budget = %d, want 8192", got)
+	}
+	if got := cfg.EffectiveTemperature(); got == nil || *got != 0.1 {
+		t.Fatalf("legacy temperature = %v, want 0.1", got)
+	}
+}
+
+func TestAIConfigExplicitValuesOverrideDefaults(t *testing.T) {
+	temp := 0.35
+	cfg := AIConfig{
+		ModelName:       "gpt-5.6-sol",
+		MaxInputTokens:  120000,
+		MaxOutputTokens: 24000,
+		ReasoningEffort: "high",
+		TemperatureOpt:  &temp,
+	}
+	if got := cfg.EffectiveMaxInputTokens(); got != 120000 {
+		t.Fatalf("input budget = %d", got)
+	}
+	if got := cfg.EffectiveMaxOutputTokens(); got != 24000 {
+		t.Fatalf("output budget = %d", got)
+	}
+	if got := cfg.EffectiveReasoningEffort(); got != "high" {
+		t.Fatalf("reasoning effort = %q", got)
+	}
+	if got := cfg.EffectiveTemperature(); got == nil || *got != temp {
+		t.Fatalf("temperature = %v", got)
+	}
+}
+
+func TestBuildOpenAICompatibleRequestUsesProviderAwareParameters(t *testing.T) {
+	messages := []map[string]interface{}{{"role": "user", "content": "hello"}}
+
+	gpt := AIConfig{ModelName: "gpt-5.6-sol", MaxTokens: 81920, Temperature: 0.1, Thinking: true}
+	body := BuildOpenAICompatibleRequest(gpt, messages, nil, true, true)
+	if _, ok := body["thinking"]; ok {
+		t.Fatal("modern GPT request must not send non-standard thinking")
+	}
+	if _, ok := body["temperature"]; ok {
+		t.Fatal("GPT reasoning request should omit temperature by default")
+	}
+	if got := body["reasoning_effort"]; got != "medium" {
+		t.Fatalf("reasoning_effort = %v", got)
+	}
+	if got := body["max_completion_tokens"]; got != 16384 {
+		t.Fatalf("max_completion_tokens = %v", got)
+	}
+
+	grok := AIConfig{ModelName: "grok-4.5", MaxTokens: 81920, Temperature: 0.1, Thinking: true}
+	body = BuildOpenAICompatibleRequest(grok, messages, []Tool{{Type: "function"}}, true, true)
+	if got := body["temperature"]; got != 0.2 {
+		t.Fatalf("temperature = %v", got)
+	}
+	if got := body["reasoning_effort"]; got != "medium" {
+		t.Fatalf("reasoning_effort = %v", got)
+	}
+	if got := body["max_completion_tokens"]; got != 8192 {
+		t.Fatalf("max_completion_tokens = %v", got)
+	}
+}
+
+func float64Ptr(v float64) *float64 { return &v }

--- a/backend/data/ai_config_policy_test.go
+++ b/backend/data/ai_config_policy_test.go
@@ -58,6 +58,23 @@ func TestAIConfigLegacyGenericCompatibility(t *testing.T) {
 	}
 }
 
+func TestAIConfigDoesNotApplyModernReasoningDefaultsToOtherModels(t *testing.T) {
+	tests := []AIConfig{
+		{ModelName: "deepseek-chat", Provider: AIProviderAuto, Thinking: true},
+		{ModelName: "gpt-4o", Provider: AIProviderOpenAI, Thinking: true},
+		{ModelName: "grok-3", Provider: AIProviderXAI, Thinking: true},
+	}
+	for _, cfg := range tests {
+		if got := cfg.EffectiveReasoningEffort(); got != "" {
+			t.Fatalf("model %q reasoning effort = %q, want empty", cfg.ModelName, got)
+		}
+		body := BuildOpenAICompatibleRequest(cfg, nil, nil, true, true)
+		if _, ok := body["reasoning_effort"]; ok {
+			t.Fatalf("model %q unexpectedly received reasoning_effort", cfg.ModelName)
+		}
+	}
+}
+
 func TestAIConfigExplicitValuesOverrideDefaults(t *testing.T) {
 	temp := 0.35
 	cfg := AIConfig{

--- a/backend/data/alert_darwin_api_test.go
+++ b/backend/data/alert_darwin_api_test.go
@@ -4,10 +4,7 @@
 package data
 
 import (
-	"go-stock/backend/logger"
 	"testing"
-
-	"github.com/go-toast/toast"
 )
 
 // @Author 2lovecode
@@ -16,17 +13,8 @@ import (
 // -----------------------------------------------------------------------------------
 
 func TestAlert(t *testing.T) {
-	notification := toast.Notification{
-		AppID:    "go-stock",
-		Title:    "Hello, World!",
-		Message:  "This is a toast notification.",
-		Icon:     "../../build/appicon.png",
-		Duration: "short",
-		Audio:    toast.Default,
-	}
-	err := notification.Push()
-	if err != nil {
-		logger.SugaredLogger.Error(err)
-		return
+	notification := NewAlertWindowsApi("go-stock", "Hello, World!", "This is a native notification.", "../../build/appicon.png")
+	if notification.AppID != "go-stock" || notification.Title != "Hello, World!" {
+		t.Fatalf("unexpected notification: %+v", notification)
 	}
 }

--- a/backend/data/openai_api.go
+++ b/backend/data/openai_api.go
@@ -3,6 +3,7 @@ package data
 import (
 	"context"
 	"fmt"
+	"go-stock/backend/logger"
 
 	"github.com/samber/lo"
 )
@@ -13,6 +14,7 @@ import (
 // -----------------------------------------------------------------------------------
 type OpenAi struct {
 	ctx              context.Context
+	aiConfig         AIConfig
 	BaseUrl          string  `json:"base_url"`
 	ApiKey           string  `json:"api_key"`
 	Model            string  `json:"model"`
@@ -66,12 +68,13 @@ func NewDeepSeekOpenAi(ctx context.Context, aiConfigId int) *OpenAi {
 	}
 	o := &OpenAi{
 		ctx:              ctx,
+		aiConfig:         *aiConfig,
 		BaseUrl:          aiConfig.BaseUrl,
 		ApiKey:           aiConfig.ApiKey,
 		Model:            aiConfig.ModelName,
-		MaxTokens:        aiConfig.MaxTokens,
+		MaxTokens:        aiConfig.EffectiveMaxOutputTokens(),
 		Temperature:      aiConfig.Temperature,
-		TimeOut:          aiConfig.TimeOut,
+		TimeOut:          aiConfig.EffectiveTimeout(),
 		HttpProxy:        aiConfig.HttpProxy,
 		HttpProxyEnabled: aiConfig.HttpProxyEnabled,
 		Prompt:           settingConfig.Prompt,
@@ -80,5 +83,10 @@ func NewDeepSeekOpenAi(ctx context.Context, aiConfigId int) *OpenAi {
 		KDays:            settingConfig.KDays,
 		BrowserPath:      settingConfig.BrowserPath,
 	}
+	logger.SugaredLogger.Infof(
+		"AI policy model=%q family=%s input_tokens=%d output_tokens=%d reasoning=%q temperature_set=%v timeout=%ds",
+		aiConfig.ModelName, aiConfig.Family(), aiConfig.EffectiveMaxInputTokens(), aiConfig.EffectiveMaxOutputTokens(),
+		aiConfig.EffectiveReasoningEffort(), aiConfig.EffectiveTemperature() != nil, aiConfig.EffectiveTimeout(),
+	)
 	return o
 }

--- a/backend/data/openai_context.go
+++ b/backend/data/openai_context.go
@@ -1,0 +1,240 @@
+package data
+
+import (
+	"encoding/json"
+	"fmt"
+	"go-stock/backend/logger"
+	"strings"
+	"unicode"
+)
+
+type OpenAIContextStats struct {
+	BeforeTokens    int
+	AfterTokens     int
+	BudgetTokens    int
+	DroppedMessages int
+	Truncated       bool
+}
+
+func logOpenAIContextStats(model string, stats OpenAIContextStats) {
+	if stats.BeforeTokens <= stats.AfterTokens {
+		return
+	}
+	logger.SugaredLogger.Infof(
+		"AI context trimmed model=%q before_tokens=%d after_tokens=%d budget_tokens=%d dropped_messages=%d truncated=%v",
+		model, stats.BeforeTokens, stats.AfterTokens, stats.BudgetTokens, stats.DroppedMessages, stats.Truncated,
+	)
+}
+
+// PrepareOpenAIMessages applies one context policy to both plain and tool-based
+// direct requests. It returns a copy, keeps system instructions and recent
+// conversation, and treats an assistant tool call plus its tool results as one
+// atomic segment so providers never receive orphan tool messages.
+func PrepareOpenAIMessages(messages []map[string]interface{}, tools []Tool, maxInputTokens int) ([]map[string]interface{}, OpenAIContextStats) {
+	cloned := cloneOpenAIMessages(messages)
+	stats := OpenAIContextStats{BeforeTokens: estimateOpenAIValueTokens(cloned)}
+	if maxInputTokens <= 0 {
+		maxInputTokens = 120000
+	}
+	overhead := 1000 + estimateOpenAIValueTokens(tools)
+	budget := maxInputTokens - overhead
+	if budget < 1000 {
+		budget = max(1000, maxInputTokens/2)
+	}
+	stats.BudgetTokens = budget
+	if stats.BeforeTokens <= budget {
+		stats.AfterTokens = stats.BeforeTokens
+		return cloned, stats
+	}
+
+	contentCap := max(1000, budget/2)
+	for _, message := range cloned {
+		content, ok := message["content"].(string)
+		messageCap := contentCap
+		if roleOf(message) == "system" {
+			messageCap = max(1000, budget/3)
+		}
+		if !ok || estimateOpenAITextTokens(content) <= messageCap {
+			continue
+		}
+		message["content"] = truncateOpenAIText(content, messageCap)
+		stats.Truncated = true
+	}
+
+	systems := make([]map[string]interface{}, 0, 1)
+	nonSystem := make([]map[string]interface{}, 0, len(cloned))
+	for _, message := range cloned {
+		if roleOf(message) == "system" {
+			systems = append(systems, message)
+		} else {
+			nonSystem = append(nonSystem, message)
+		}
+	}
+	segments := openAIMessageSegments(nonSystem)
+	if len(segments) > 0 {
+		// Always reserve room for the newest user/assistant segment. A very large
+		// system prompt must not crowd the actual request out of the payload.
+		systemBudget := budget - max(256, budget/3)
+		if estimateOpenAIValueTokens(systems) > systemBudget {
+			if shrunk := shrinkOpenAISegmentToBudget(systems, systemBudget); shrunk != nil {
+				systems = shrunk
+				stats.Truncated = true
+			}
+		}
+	}
+	remaining := budget - estimateOpenAIValueTokens(systems)
+	if remaining < 0 {
+		for _, message := range systems {
+			if content, ok := message["content"].(string); ok {
+				message["content"] = truncateOpenAIText(content, max(500, budget/max(2, len(systems))))
+				stats.Truncated = true
+			}
+		}
+		remaining = max(0, budget-estimateOpenAIValueTokens(systems))
+	}
+
+	selected := make([][]map[string]interface{}, 0, len(segments))
+	for i := len(segments) - 1; i >= 0; i-- {
+		segment := segments[i]
+		segmentTokens := estimateOpenAIValueTokens(segment)
+		if segmentTokens > remaining && len(selected) == 0 {
+			// The newest segment is mandatory. Shrink its content further while
+			// retaining assistant/tool-call atomicity.
+			if shrunk := shrinkOpenAISegmentToBudget(segment, remaining); shrunk != nil {
+				segment = shrunk
+				segmentTokens = estimateOpenAIValueTokens(segment)
+				stats.Truncated = true
+			}
+		}
+		if segmentTokens > remaining {
+			continue
+		}
+		selected = append([][]map[string]interface{}{segment}, selected...)
+		remaining -= segmentTokens
+	}
+
+	result := append([]map[string]interface{}{}, systems...)
+	for _, segment := range selected {
+		result = append(result, segment...)
+	}
+	stats.DroppedMessages = len(cloned) - len(result)
+	stats.AfterTokens = estimateOpenAIValueTokens(result)
+	return result, stats
+}
+
+func shrinkOpenAISegmentToBudget(segment []map[string]interface{}, budget int) []map[string]interface{} {
+	if budget <= 0 {
+		return nil
+	}
+	for attempts := 0; attempts < len(segment)*4+4; attempts++ {
+		current := estimateOpenAIValueTokens(segment)
+		if current <= budget {
+			return segment
+		}
+		largestIndex, largestTokens := -1, 0
+		for i, message := range segment {
+			content, ok := message["content"].(string)
+			if !ok {
+				continue
+			}
+			if tokens := estimateOpenAITextTokens(content); tokens > largestTokens {
+				largestIndex, largestTokens = i, tokens
+			}
+		}
+		if largestIndex < 0 || largestTokens <= 16 {
+			return nil
+		}
+		target := max(16, largestTokens-(current-budget)-16)
+		segment[largestIndex]["content"] = truncateOpenAIText(segment[largestIndex]["content"].(string), target)
+	}
+	if estimateOpenAIValueTokens(segment) <= budget {
+		return segment
+	}
+	return nil
+}
+
+func openAIMessageSegments(messages []map[string]interface{}) [][]map[string]interface{} {
+	segments := make([][]map[string]interface{}, 0, len(messages))
+	for i := 0; i < len(messages); i++ {
+		message := messages[i]
+		role := roleOf(message)
+		if role == "tool" {
+			continue
+		}
+		segment := []map[string]interface{}{message}
+		if role == "assistant" {
+			if _, hasToolCalls := message["tool_calls"]; hasToolCalls {
+				for i+1 < len(messages) && roleOf(messages[i+1]) == "tool" {
+					i++
+					segment = append(segment, messages[i])
+				}
+			}
+		}
+		segments = append(segments, segment)
+	}
+	return segments
+}
+
+func cloneOpenAIMessages(messages []map[string]interface{}) []map[string]interface{} {
+	encoded, err := json.Marshal(messages)
+	if err == nil {
+		var cloned []map[string]interface{}
+		if json.Unmarshal(encoded, &cloned) == nil {
+			return cloned
+		}
+	}
+	cloned := make([]map[string]interface{}, 0, len(messages))
+	for _, message := range messages {
+		copyMessage := make(map[string]interface{}, len(message))
+		for key, value := range message {
+			copyMessage[key] = value
+		}
+		cloned = append(cloned, copyMessage)
+	}
+	return cloned
+}
+
+func roleOf(message map[string]interface{}) string {
+	return strings.ToLower(strings.TrimSpace(fmt.Sprint(message["role"])))
+}
+
+func estimateOpenAIValueTokens(value interface{}) int {
+	encoded, err := json.Marshal(value)
+	if err != nil {
+		return estimateOpenAITextTokens(fmt.Sprint(value))
+	}
+	return estimateOpenAITextTokens(string(encoded))
+}
+
+func estimateOpenAITextTokens(text string) int {
+	if text == "" {
+		return 0
+	}
+	han, other := 0, 0
+	for _, r := range text {
+		if unicode.Is(unicode.Han, r) {
+			han++
+		} else {
+			other++
+		}
+	}
+	return int(float64(han)/1.5+float64(other)/4.0) + 1
+}
+
+func truncateOpenAIText(text string, maxTokens int) string {
+	if estimateOpenAITextTokens(text) <= maxTokens {
+		return text
+	}
+	marker := "\n\n...(内容过长，已按输入预算截断)...\n\n"
+	runes := []rune(text)
+	keep := min(len(runes), max(100, maxTokens*2))
+	for keep > 100 {
+		head := keep * 7 / 10
+		candidate := string(runes[:head]) + marker + string(runes[len(runes)-(keep-head):])
+		if estimateOpenAITextTokens(candidate) <= maxTokens {
+			return candidate
+		}
+		keep = keep * 4 / 5
+	}
+	return string(runes[:min(len(runes), 100)]) + marker
+}

--- a/backend/data/openai_context_test.go
+++ b/backend/data/openai_context_test.go
@@ -1,0 +1,82 @@
+package data
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestPrepareOpenAIMessagesDropsOldHistoryAndKeepsCurrentQuestion(t *testing.T) {
+	messages := []map[string]interface{}{
+		{"role": "system", "content": "system rules"},
+		{"role": "user", "content": "old question " + strings.Repeat("x", 18000)},
+		{"role": "assistant", "content": "old answer " + strings.Repeat("y", 18000)},
+		{"role": "user", "content": "current question"},
+	}
+
+	got, stats := PrepareOpenAIMessages(messages, nil, 5000)
+	if stats.DroppedMessages == 0 && !stats.Truncated {
+		t.Fatal("expected old history to be dropped or truncated")
+	}
+	if roleOf(got[0]) != "system" {
+		t.Fatalf("first role = %q, want system", roleOf(got[0]))
+	}
+	last := got[len(got)-1]
+	if last["content"] != "current question" {
+		t.Fatalf("last content = %q", last["content"])
+	}
+	if stats.AfterTokens > stats.BudgetTokens {
+		t.Fatalf("after tokens %d exceeds budget %d", stats.AfterTokens, stats.BudgetTokens)
+	}
+	if messages[1]["content"] == nil || !strings.Contains(messages[1]["content"].(string), "old question") {
+		t.Fatal("input messages were mutated")
+	}
+}
+
+func TestPrepareOpenAIMessagesKeepsToolCallPairWithoutOrphans(t *testing.T) {
+	messages := []map[string]interface{}{
+		{"role": "system", "content": "system"},
+		{"role": "user", "content": "analyze"},
+		{"role": "assistant", "content": "", "tool_calls": []map[string]any{{"id": "call_1", "type": "function"}}},
+		{"role": "tool", "tool_call_id": "call_1", "content": strings.Repeat("market-data ", 6000)},
+	}
+
+	got, stats := PrepareOpenAIMessages(messages, nil, 5000)
+	if !stats.Truncated {
+		t.Fatal("expected oversized tool result to be truncated")
+	}
+	assistantIndex := -1
+	for i, message := range got {
+		if roleOf(message) == "assistant" {
+			assistantIndex = i
+		}
+		if roleOf(message) == "tool" && assistantIndex < 0 {
+			t.Fatal("tool message was kept without its assistant tool call")
+		}
+	}
+	if assistantIndex < 0 || roleOf(got[len(got)-1]) != "tool" {
+		t.Fatalf("tool call pair not preserved: %#v", got)
+	}
+	if stats.AfterTokens > stats.BudgetTokens {
+		t.Fatalf("after tokens %d exceeds budget %d", stats.AfterTokens, stats.BudgetTokens)
+	}
+}
+
+func TestPrepareOpenAIMessagesNeverDropsNewestQuestionBehindLargeSystemPrompts(t *testing.T) {
+	messages := []map[string]interface{}{
+		{"role": "system", "content": strings.Repeat("规则甲", 4000)},
+		{"role": "system", "content": strings.Repeat("规则乙", 4000)},
+		{"role": "user", "content": strings.Repeat("请分析", 4000) + " CURRENT_QUESTION_END"},
+	}
+
+	got, stats := PrepareOpenAIMessages(messages, nil, 1800)
+	if len(got) < 2 {
+		t.Fatalf("newest question was dropped: %#v", got)
+	}
+	last := got[len(got)-1]
+	if roleOf(last) != "user" || !strings.Contains(last["content"].(string), "CURRENT_QUESTION_END") {
+		t.Fatalf("newest question not retained at the end: %#v", last)
+	}
+	if stats.AfterTokens > stats.BudgetTokens {
+		t.Fatalf("after tokens %d exceeds budget %d", stats.AfterTokens, stats.BudgetTokens)
+	}
+}

--- a/backend/data/openai_tools.go
+++ b/backend/data/openai_tools.go
@@ -335,31 +335,11 @@ func AskAi(o *OpenAi, err error, messages []map[string]interface{}, ch chan map[
 	baseURL, chatPath := openAIChatEndpoint(o.BaseUrl)
 	client.SetBaseURL(baseURL)
 
-	thinking := "disabled"
-	if think {
-		thinking = "enabled"
-	}
-
 	if !think {
 		messages = stripReasoningContent(messages)
 	}
 
-	bodyMap := map[string]interface{}{
-		"model":    o.Model,
-		"stream":   true,
-		"messages": messages,
-	}
-	if o.Temperature > 0 {
-		bodyMap["temperature"] = o.Temperature
-	}
-	if o.MaxTokens > 0 {
-		bodyMap["max_tokens"] = o.MaxTokens
-	}
-	if think {
-		bodyMap["thinking"] = map[string]any{
-			"type": thinking,
-		}
-	}
+	bodyMap := BuildOpenAICompatibleRequest(o.aiConfig, messages, nil, true, think)
 
 	req := client.R().
 		SetDoNotParseResponse(true).
@@ -558,23 +538,7 @@ func AskAiWithToolsDepth(o *OpenAi, err error, messages []map[string]interface{}
 		messages = stripReasoningContent(messages)
 	}
 
-	bodyMap := map[string]interface{}{
-		"model":    o.Model,
-		"stream":   true,
-		"messages": messages,
-		"tools":    tools,
-	}
-	if o.Temperature > 0 {
-		bodyMap["temperature"] = o.Temperature
-	}
-	if o.MaxTokens > 0 {
-		bodyMap["max_tokens"] = o.MaxTokens
-	}
-	if thinkingMode {
-		bodyMap["thinking"] = map[string]any{
-			"type": "enabled",
-		}
-	}
+	bodyMap := BuildOpenAICompatibleRequest(o.aiConfig, messages, tools, true, thinkingMode)
 
 	reqBody, _ := json.Marshal(bodyMap)
 	if len(reqBody) > 100000 {

--- a/backend/data/openai_tools.go
+++ b/backend/data/openai_tools.go
@@ -338,6 +338,8 @@ func AskAi(o *OpenAi, err error, messages []map[string]interface{}, ch chan map[
 	if !think {
 		messages = stripReasoningContent(messages)
 	}
+	messages, contextStats := PrepareOpenAIMessages(messages, nil, o.aiConfig.EffectiveMaxInputTokens())
+	logOpenAIContextStats(o.Model, contextStats)
 
 	bodyMap := BuildOpenAICompatibleRequest(o.aiConfig, messages, nil, true, think)
 
@@ -537,6 +539,8 @@ func AskAiWithToolsDepth(o *OpenAi, err error, messages []map[string]interface{}
 	if !thinkingMode {
 		messages = stripReasoningContent(messages)
 	}
+	messages, contextStats := PrepareOpenAIMessages(messages, tools, o.aiConfig.EffectiveMaxInputTokens())
+	logOpenAIContextStats(o.Model, contextStats)
 
 	bodyMap := BuildOpenAICompatibleRequest(o.aiConfig, messages, tools, true, thinkingMode)
 

--- a/backend/data/settings_api.go
+++ b/backend/data/settings_api.go
@@ -66,17 +66,22 @@ type AIConfig struct {
 	ID               uint `gorm:"primarykey"`
 	CreatedAt        time.Time
 	UpdatedAt        time.Time
-	Name             string  `json:"name"`
-	BaseUrl          string  `json:"baseUrl"`
-	ApiKey           string  `json:"apiKey" `
-	ModelName        string  `json:"modelName"`
-	MaxTokens        int     `json:"maxTokens"`
-	Temperature      float64 `json:"temperature"`
-	TimeOut          int     `json:"timeOut"`
-	HttpProxy        string  `json:"httpProxy"`
-	HttpProxyEnabled bool    `json:"httpProxyEnabled"`
-	SessionId        string  `json:"sessionId" gorm:"index;size:64"`
-	Thinking         bool    `json:"thinking"`
+	Name             string   `json:"name"`
+	BaseUrl          string   `json:"baseUrl"`
+	ApiKey           string   `json:"apiKey" `
+	ModelName        string   `json:"modelName"`
+	Provider         string   `json:"provider" gorm:"size:32"`
+	MaxTokens        int      `json:"maxTokens"`
+	MaxInputTokens   int      `json:"maxInputTokens" gorm:"column:max_input_tokens"`
+	MaxOutputTokens  int      `json:"maxOutputTokens" gorm:"column:max_output_tokens"`
+	Temperature      float64  `json:"temperature"`
+	TemperatureOpt   *float64 `json:"temperatureOpt" gorm:"column:temperature_opt"`
+	ReasoningEffort  string   `json:"reasoningEffort" gorm:"column:reasoning_effort;size:16"`
+	TimeOut          int      `json:"timeOut"`
+	HttpProxy        string   `json:"httpProxy"`
+	HttpProxyEnabled bool     `json:"httpProxyEnabled"`
+	SessionId        string   `json:"sessionId" gorm:"index;size:64"`
+	Thinking         bool     `json:"thinking"`
 }
 
 func (AIConfig) TableName() string {
@@ -240,8 +245,13 @@ func updateAiConfigs(aiConfigs []*AIConfig) error {
 				"base_url":           item.BaseUrl,
 				"api_key":            item.ApiKey,
 				"model_name":         item.ModelName,
+				"provider":           item.Provider,
 				"max_tokens":         item.MaxTokens,
+				"max_input_tokens":   item.MaxInputTokens,
+				"max_output_tokens":  item.MaxOutputTokens,
 				"temperature":        item.Temperature,
+				"temperature_opt":    item.TemperatureOpt,
+				"reasoning_effort":   item.ReasoningEffort,
 				"time_out":           item.TimeOut,
 				"http_proxy":         item.HttpProxy,
 				"http_proxy_enabled": item.HttpProxyEnabled,

--- a/backend/data/sponsor_vip.go
+++ b/backend/data/sponsor_vip.go
@@ -3,6 +3,7 @@ package data
 import (
 	"encoding/hex"
 	"encoding/json"
+	"fmt"
 	"strings"
 	"time"
 
@@ -17,6 +18,34 @@ const DefaultSponsorAESKeyHex = ""
 // SponsorDecryptKeyHex 由主程序在启动时同步为 ldflags 注入的 BuildKey；为空则使用 DefaultSponsorAESKeyHex。
 var SponsorDecryptKeyHex string
 
+// DecodeSponsorInfo is the single safe seam for sponsor payload decryption.
+// lancet's AES helper panics on invalid padding, so malformed data and local
+// development builds without an injected key must be converted to errors.
+func DecodeSponsorInfo(sponsorCode, keyHex string) (info map[string]any, err error) {
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			info = nil
+			err = fmt.Errorf("decrypt sponsor payload: %v", recovered)
+		}
+	}()
+	encrypted, err := hex.DecodeString(strings.TrimSpace(sponsorCode))
+	if err != nil || len(encrypted) == 0 {
+		return nil, fmt.Errorf("invalid sponsor payload encoding")
+	}
+	key, err := hex.DecodeString(strings.TrimSpace(keyHex))
+	if err != nil || (len(key) != 16 && len(key) != 24 && len(key) != 32) {
+		return nil, fmt.Errorf("invalid sponsor decryption key")
+	}
+	raw := cryptor.AesEcbDecrypt(encrypted, key)
+	if len(raw) == 0 {
+		return nil, fmt.Errorf("empty sponsor payload")
+	}
+	if err := json.Unmarshal(raw, &info); err != nil {
+		return nil, fmt.Errorf("decode sponsor payload: %w", err)
+	}
+	return info, nil
+}
+
 // EffectiveSponsorVipLevel 根据设置中的 sponsorCode 解析 VIP 等级，并按 vipAuthTime / vipStartTime / vipEndTime 判断是否当前有效。
 // 与 app.isVip 时间判断逻辑保持一致。
 func EffectiveSponsorVipLevel() (level int, active bool) {
@@ -28,20 +57,8 @@ func EffectiveSponsorVipLevel() (level int, active bool) {
 	if sponsorCode == "" {
 		return 0, false
 	}
-	encrypted, err := hex.DecodeString(sponsorCode)
+	info, err := DecodeSponsorInfo(sponsorCode, keyHex)
 	if err != nil {
-		return 0, false
-	}
-	key, err := hex.DecodeString(keyHex)
-	if err != nil {
-		return 0, false
-	}
-	raw := cryptor.AesEcbDecrypt(encrypted, key)
-	if len(raw) == 0 {
-		return 0, false
-	}
-	var info map[string]any
-	if err := json.Unmarshal(raw, &info); err != nil {
 		return 0, false
 	}
 	lvl64, _ := convertor.ToInt(info["vipLevel"])

--- a/backend/data/sponsor_vip_test.go
+++ b/backend/data/sponsor_vip_test.go
@@ -1,0 +1,22 @@
+package data
+
+import "testing"
+
+func TestDecodeSponsorInfoRejectsMissingKeyAndCorruptPayloadWithoutPanicking(t *testing.T) {
+	tests := []struct {
+		name string
+		code string
+		key  string
+	}{
+		{name: "missing key", code: "0011", key: ""},
+		{name: "invalid key size", code: "0011", key: "00"},
+		{name: "corrupt encrypted payload", code: "00112233445566778899aabbccddeeff", key: "00112233445566778899aabbccddeeff"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if _, err := DecodeSponsorInfo(tt.code, tt.key); err == nil {
+				t.Fatal("expected decode error")
+			}
+		})
+	}
+}

--- a/docs/AI_PROVIDER_CONFIGURATION.md
+++ b/docs/AI_PROVIDER_CONFIGURATION.md
@@ -17,6 +17,14 @@ limit does not improve answer quality by itself and increases latency and cost.
 The direct OpenAI-compatible API remains the default path for streaming, tools,
 scheduled jobs, and chat. GPT/Grok reasoning is sent as `reasoning_effort`; the
 non-standard `thinking` object is retained only for legacy compatible providers.
+The transport intentionally remains Chat Completions because go-stock's current
+streaming tool loop and the configured local proxy are verified against that
+protocol. Responses API support should be added as a separate adapter instead of
+silently changing the existing streaming contract.
+
+Direct requests also apply the configured input budget before every model call.
+Oversized tool results are truncated, old history is removed, and assistant/tool
+pairs remain atomic so the provider never receives orphan tool messages.
 
 ## Local Codex deep analysis
 
@@ -27,6 +35,8 @@ installed `codex exec` with:
   configuration files;
 - `--ephemeral`, a read-only sandbox, and no Git-repository requirement;
 - one job at a time, a ten-minute timeout, GPT-5.6 Sol, and medium reasoning;
+- cancellation from the Agent assistant, including while waiting for the single
+  execution slot;
 - no automatic fallback to a paid API provider.
 
 This path is intended for deliberate, long-running analysis. It is not used by

--- a/docs/AI_PROVIDER_CONFIGURATION.md
+++ b/docs/AI_PROVIDER_CONFIGURATION.md
@@ -1,0 +1,33 @@
+# AI provider configuration
+
+go-stock separates the input context budget from the maximum model output. The
+legacy `maxTokens` column remains supported for older configurations, while new
+configurations should use `maxInputTokens` and `maxOutputTokens`.
+
+## Recommended profiles
+
+| Model | Provider | Input | Output | Reasoning | Temperature | Timeout |
+| --- | --- | ---: | ---: | --- | ---: | ---: |
+| GPT-5.6 Sol | OpenAI / GPT | 96,000 | 16,384 | medium | omitted | 900 s |
+| Grok 4.5 | xAI / Grok | 96,000 | 8,192 | medium | 0.2 | 600 s |
+
+Use `high` reasoning only for explicit deep-analysis work. Raising the output
+limit does not improve answer quality by itself and increases latency and cost.
+
+The direct OpenAI-compatible API remains the default path for streaming, tools,
+scheduled jobs, and chat. GPT/Grok reasoning is sent as `reasoning_effort`; the
+non-standard `thinking` object is retained only for legacy compatible providers.
+
+## Local Codex deep analysis
+
+The Agent assistant exposes a separate **Codex 深度分析** action. It runs the
+installed `codex exec` with:
+
+- an isolated temporary `CODEX_HOME` containing copies of the current auth and
+  configuration files;
+- `--ephemeral`, a read-only sandbox, and no Git-repository requirement;
+- one job at a time, a ten-minute timeout, GPT-5.6 Sol, and medium reasoning;
+- no automatic fallback to a paid API provider.
+
+This path is intended for deliberate, long-running analysis. It is not used by
+cron tasks or as the normal chat transport.

--- a/frontend/src/components/FloatingAgentAssistant.vue
+++ b/frontend/src/components/FloatingAgentAssistant.vue
@@ -283,7 +283,7 @@
                   @keydown.enter.exact.prevent="sendMessage"
                 />
                 <NButton
-                  v-if="isStreamLoad"
+                  v-if="isStreamLoad && !isCodexLoad"
                   type="warning"
                   quaternary
                   class="chat-footer-abort"
@@ -298,6 +298,16 @@
                   @click="sendMessage"
                 >
                   发送
+                </NButton>
+                <NButton
+                  secondary
+                  type="info"
+                  :loading="isStreamLoad"
+                  :disabled="isStreamLoad || !canSend"
+                  title="调用本机 Codex CLI（只读、最长 10 分钟）"
+                  @click="sendCodexDeepAnalysis"
+                >
+                  Codex 深度分析
                 </NButton>
               </div>
             </div>
@@ -333,7 +343,8 @@ import {
   ShareText,
   AbortChatWithAgent,
   SaveAIResponseResult,
-  SaveImage
+  SaveImage,
+  RunCodexDeepAnalysis
 } from '../../wailsjs/go/main/App'
 import { EventsOff, EventsOn } from '../../wailsjs/runtime'
 import { MdPreview } from 'md-editor-v3'
@@ -350,6 +361,7 @@ const showButton = computed(() => route.name !== 'agent')
 const panelVisible = ref(false)
 const inputValue = ref('')
 const isStreamLoad = ref(false)
+const isCodexLoad = ref(false)
 const sentFromFloating = ref(false)
 const messages = ref([])
 let formatTimer = null
@@ -862,6 +874,7 @@ function sendMessage() {
   })
   inputValue.value = ''
   isStreamLoad.value = true
+  isCodexLoad.value = false
   isAborted.value = false
   sentFromFloating.value = true
   startFormatTimer()
@@ -879,6 +892,40 @@ function sendMessage() {
     scrollToBottom()
   })
   ChatWithAgent(text, configId, sysPromptId.value, memoryMode.value, memoryCount.value, thinkingMode.value, agentMode.value === 'auto' ? '' : agentMode.value)
+}
+
+async function sendCodexDeepAnalysis() {
+  const text = inputValue.value.trim()
+  if (!text) {
+    message.warning('请输入你的问题')
+    return
+  }
+  messages.value.push({role: 'user', content: text, time: new Date().toLocaleString(), modelName: '', reasoning: '', steps: []})
+  messages.value.push({role: 'assistant', content: '', rawContent: '', time: new Date().toLocaleString(), modelName: 'Codex / gpt-5.6-sol', reasoning: '', rawReasoning: '', steps: [], jsonMarkdown: ''})
+  inputValue.value = ''
+  isStreamLoad.value = true
+  isCodexLoad.value = true
+  saveHistory()
+  scrollToBottom()
+  try {
+    const result = await RunCodexDeepAnalysis(text, 'gpt-5.6-sol', 'medium')
+    const last = messages.value[messages.value.length - 1]
+    if (result?.ok) {
+      const formatted = formatMarkdown(String(result.content || ''))
+      last.rawContent = String(result.content || '')
+      last.content = formatted.content
+      last.jsonMarkdown = formatted.jsonMarkdown
+    } else {
+      last.content = `Codex 深度分析失败：${result?.error || '未知错误'}`
+    }
+  } catch (e) {
+    messages.value[messages.value.length - 1].content = `Codex 深度分析失败：${e?.message ?? e}`
+  } finally {
+    isStreamLoad.value = false
+    isCodexLoad.value = false
+    saveHistory()
+    scrollToBottom()
+  }
 }
 
 function startNewChat() {
@@ -1206,7 +1253,8 @@ onMounted(() => {
       const modelName = c.modelName ?? c.ModelName ?? ''
       return {
         label: name + (modelName ? ' [' + modelName + ']' : ''),
-        value: id
+        value: id,
+        modelName
       }
     })
     if (aiConfigOptions.value.length) {

--- a/frontend/src/components/FloatingAgentAssistant.vue
+++ b/frontend/src/components/FloatingAgentAssistant.vue
@@ -283,7 +283,7 @@
                   @keydown.enter.exact.prevent="sendMessage"
                 />
                 <NButton
-                  v-if="isStreamLoad && !isCodexLoad"
+                  v-if="isStreamLoad"
                   type="warning"
                   quaternary
                   class="chat-footer-abort"
@@ -342,6 +342,7 @@ import {
   GetAiAssistantSession,
   ShareText,
   AbortChatWithAgent,
+  AbortCodexDeepAnalysis,
   SaveAIResponseResult,
   SaveImage,
   RunCodexDeepAnalysis
@@ -362,6 +363,7 @@ const panelVisible = ref(false)
 const inputValue = ref('')
 const isStreamLoad = ref(false)
 const isCodexLoad = ref(false)
+let activeCodexRun = null
 const sentFromFloating = ref(false)
 const messages = ref([])
 let formatTimer = null
@@ -718,6 +720,21 @@ async function exportAiReplyImage(assistantIndex, evt) {
 
 function abortStream(showTip = true) {
   if (!isStreamLoad.value) return
+  if (isCodexLoad.value) {
+    activeCodexRun = null
+    isAborted.value = true
+    isCodexLoad.value = false
+    isStreamLoad.value = false
+    const last = messages.value[messages.value.length - 1]
+    if (last && last.role === 'assistant' && !last.content) last.content = 'Codex 深度分析已中断'
+    AbortCodexDeepAnalysis()
+    saveHistory()
+    if (showTip) {
+      shareTipText.value = '已中断本次 Codex 深度分析'
+      shareTipVisible.value = true
+    }
+    return
+  }
   isAborted.value = true
   isStreamLoad.value = false
   stopFormatTimer()
@@ -905,10 +922,13 @@ async function sendCodexDeepAnalysis() {
   inputValue.value = ''
   isStreamLoad.value = true
   isCodexLoad.value = true
+  const runToken = Symbol('codex-run')
+  activeCodexRun = runToken
   saveHistory()
   scrollToBottom()
   try {
     const result = await RunCodexDeepAnalysis(text, 'gpt-5.6-sol', 'medium')
+    if (activeCodexRun !== runToken) return
     const last = messages.value[messages.value.length - 1]
     if (result?.ok) {
       const formatted = formatMarkdown(String(result.content || ''))
@@ -919,12 +939,16 @@ async function sendCodexDeepAnalysis() {
       last.content = `Codex 深度分析失败：${result?.error || '未知错误'}`
     }
   } catch (e) {
+    if (activeCodexRun !== runToken) return
     messages.value[messages.value.length - 1].content = `Codex 深度分析失败：${e?.message ?? e}`
   } finally {
-    isStreamLoad.value = false
-    isCodexLoad.value = false
-    saveHistory()
-    scrollToBottom()
+    if (activeCodexRun === runToken) {
+      activeCodexRun = null
+      isStreamLoad.value = false
+      isCodexLoad.value = false
+      saveHistory()
+      scrollToBottom()
+    }
   }
 }
 

--- a/frontend/src/components/ai-config-manager.vue
+++ b/frontend/src/components/ai-config-manager.vue
@@ -114,6 +114,11 @@ const reasoningEffortOptions = [
   {label: '高（深度分析）', value: 'high'},
 ]
 
+function supportsStandardReasoningEffort(modelName) {
+  const model = (modelName || '').trim().toLowerCase()
+  return model.startsWith('gpt-5') || model.startsWith('grok-4.5')
+}
+
 function applyRecommendedConfig(aiConfig) {
   const model = (aiConfig.modelName || '').toLowerCase()
   if (model.startsWith('gpt-5')) {
@@ -237,7 +242,7 @@ function openAddDrawer() {
     maxTokens: 8192,
     maxInputTokens: 0,
     maxOutputTokens: 0,
-    reasoningEffort: 'medium',
+    reasoningEffort: '',
     timeOut: 6000,
     httpProxy: "",
     httpProxyEnabled: false,
@@ -411,7 +416,7 @@ function loadAiConfigs() {
       maxInputTokens: config.maxInputTokens || 0,
       maxOutputTokens: config.maxOutputTokens || 0,
       temperatureOpt: config.temperatureOpt ?? null,
-      reasoningEffort: config.reasoningEffort || 'medium',
+      reasoningEffort: config.reasoningEffort || (supportsStandardReasoningEffort(config.modelName) ? 'medium' : ''),
     }))
   })
 }

--- a/frontend/src/components/ai-config-manager.vue
+++ b/frontend/src/components/ai-config-manager.vue
@@ -101,6 +101,44 @@ const aiPlatformOptions = [
   {label: 'Ollama (http://localhost:11434/v1)', value: 'http://localhost:11434/v1'},
 ]
 
+const providerOptions = [
+  {label: '自动识别（推荐）', value: 'auto'},
+  {label: 'OpenAI / GPT', value: 'openai'},
+  {label: 'xAI / Grok', value: 'xai'},
+  {label: '通用 OpenAI 兼容', value: 'openai_compatible'},
+]
+
+const reasoningEffortOptions = [
+  {label: '低（更快）', value: 'low'},
+  {label: '中（推荐）', value: 'medium'},
+  {label: '高（深度分析）', value: 'high'},
+]
+
+function applyRecommendedConfig(aiConfig) {
+  const model = (aiConfig.modelName || '').toLowerCase()
+  if (model.startsWith('gpt-5')) {
+    aiConfig.provider = 'openai'
+    aiConfig.maxInputTokens = 96000
+    aiConfig.maxOutputTokens = 16384
+    aiConfig.reasoningEffort = 'medium'
+    aiConfig.temperatureOpt = null
+    aiConfig.timeOut = 900
+    aiConfig.thinking = true
+  } else if (model.startsWith('grok-')) {
+    aiConfig.provider = 'xai'
+    aiConfig.maxInputTokens = 96000
+    aiConfig.maxOutputTokens = 8192
+    aiConfig.reasoningEffort = 'medium'
+    aiConfig.temperatureOpt = 0.2
+    aiConfig.timeOut = 600
+    aiConfig.thinking = true
+  } else {
+    message.info('当前模型没有内置推荐值，请按服务商文档配置')
+    return
+  }
+  message.success('已应用推荐参数，请确认后保存')
+}
+
 function getPlatformName(baseUrl) {
   if (!baseUrl) return ''
   const platform = aiPlatformOptions.find(opt => opt.value === baseUrl)
@@ -175,9 +213,9 @@ async function fetchModelInfo(aiConfig, modelName) {
   try {
     const info = await FetchAiModelInfo(aiConfig.baseUrl, aiConfig.apiKey || '', modelName)
     if (info && info.maxTokens > 0) {
-      aiConfig.maxTokens = info.maxTokens
+      aiConfig.maxInputTokens = info.maxTokens
       const sourceLabel = info.source === 'api' ? 'API' : '内置数据'
-      message.success(`已自动设置 ${modelName} 的 MaxTokens 为 ${info.maxTokens}（来源：${sourceLabel}）`)
+      message.success(`已自动设置 ${modelName} 的最大输入 Tokens 为 ${info.maxTokens}（来源：${sourceLabel}）`)
     }
   } catch (e) {
     console.error('FetchAiModelInfo error', e)
@@ -193,8 +231,13 @@ function openAddDrawer() {
     baseUrl: 'https://api.deepseek.com',
     apiKey: '',
     modelName: 'deepseek-reasoner',
+    provider: 'auto',
     temperature: 0.1,
+    temperatureOpt: null,
     maxTokens: 8192,
+    maxInputTokens: 0,
+    maxOutputTokens: 0,
+    reasoningEffort: 'medium',
     timeOut: 6000,
     httpProxy: "",
     httpProxyEnabled: false,
@@ -284,10 +327,13 @@ const columns = [
     }
   },
   {
-    title: 'MaxTokens',
-    key: 'maxTokens',
+    title: '输入 / 输出',
+    key: 'maxInputTokens',
     width: 110,
-    align: 'right'
+    align: 'right',
+    render(row) {
+      return h('span', `${row.maxInputTokens || '兼容'} / ${row.maxOutputTokens || row.maxTokens || '-'}`)
+    }
   },
   {
     title: '操作',
@@ -359,7 +405,14 @@ function saveAiConfigs() {
 
 function loadAiConfigs() {
   GetAiConfigs().then(res => {
-    aiConfigs.value = res || []
+    aiConfigs.value = (res || []).map(config => ({
+      ...config,
+      provider: config.provider || 'auto',
+      maxInputTokens: config.maxInputTokens || 0,
+      maxOutputTokens: config.maxOutputTokens || 0,
+      temperatureOpt: config.temperatureOpt ?? null,
+      reasoningEffort: config.reasoningEffort || 'medium',
+    }))
   })
 }
 
@@ -451,11 +504,26 @@ onMounted(() => {
               @update:value="(val) => onModelNameChange(editingConfig, val)"
             />
           </n-form-item>
-          <n-form-item label="Temperature">
-            <n-input-number v-model:value="editingConfig.temperature" :step="0.1" style="width: 100%;"/>
+          <n-form-item label="参数模板">
+            <n-space align="center">
+              <n-button type="primary" dashed @click="applyRecommendedConfig(editingConfig)">应用模型推荐值</n-button>
+              <n-text depth="3">GPT-5.6 Sol / Grok 4.5</n-text>
+            </n-space>
           </n-form-item>
-          <n-form-item label="MaxTokens">
-            <n-input-number v-model:value="editingConfig.maxTokens" style="width: 100%;"/>
+          <n-form-item label="Provider">
+            <n-select v-model:value="editingConfig.provider" :options="providerOptions" style="width: 100%;"/>
+          </n-form-item>
+          <n-form-item label="Temperature">
+            <n-input-number v-model:value="editingConfig.temperatureOpt" clearable :step="0.1" placeholder="留空表示不发送" style="width: 100%;"/>
+          </n-form-item>
+          <n-form-item label="最大输入Tokens">
+            <n-input-number v-model:value="editingConfig.maxInputTokens" :min="0" style="width: 100%;"/>
+          </n-form-item>
+          <n-form-item label="最大输出Tokens">
+            <n-input-number v-model:value="editingConfig.maxOutputTokens" :min="0" style="width: 100%;"/>
+          </n-form-item>
+          <n-form-item label="推理强度">
+            <n-select v-model:value="editingConfig.reasoningEffort" :options="reasoningEffortOptions" clearable style="width: 100%;"/>
           </n-form-item>
           <n-form-item label="Timeout(秒)">
             <n-input-number :min="60" :step="1" v-model:value="editingConfig.timeOut" style="width: 100%;"/>
@@ -471,9 +539,8 @@ onMounted(() => {
                 </template>
                 <n-gradient-text :type="'warning'">
                   <div style="max-width: 400px;text-align: left">
-                    启用深度思考模式：<br>
-                    适用于 DeepSeek-Reasoner、MiMo-V2.5-Pro 等支持推理的模型。<br>
-                    如使用普通模型请关闭此选项
+                    启用模型推理能力。GPT/Grok 会映射为标准 reasoning_effort，<br>
+                    其他兼容服务保留原有 thinking 兼容逻辑。普通模型请关闭。
                   </div>
                 </n-gradient-text>
               </n-tooltip>

--- a/frontend/wailsjs/go/main/App.d.ts
+++ b/frontend/wailsjs/go/main/App.d.ts
@@ -42,6 +42,8 @@ export function CalculateNextRunTimes(arg1:string,arg2:number):Promise<Array<str
 
 export function ChatWithAgent(arg1:string,arg2:number,arg3:any,arg4:boolean,arg5:number,arg6:boolean,arg7:string):Promise<void>;
 
+export function RunCodexDeepAnalysis(arg1:string,arg2:string,arg3:string):Promise<{[key: string]: any}>;
+
 export function CheckDeviceBinding(arg1:string,arg2:string):Promise<Record<string, any>>;
 
 export function CheckFrequentTrading(arg1:string):Promise<Record<string, any>>;

--- a/frontend/wailsjs/go/main/App.d.ts
+++ b/frontend/wailsjs/go/main/App.d.ts
@@ -8,6 +8,8 @@ import {lo} from '../models';
 
 export function AbortChatWithAgent():Promise<void>;
 
+export function AbortCodexDeepAnalysis():Promise<void>;
+
 export function AbortSummaryStockNews():Promise<void>;
 
 export function AddAllStockInfo(arg1:models.AllStockInfo):Promise<string>;

--- a/frontend/wailsjs/go/main/App.js
+++ b/frontend/wailsjs/go/main/App.js
@@ -74,6 +74,10 @@ export function ChatWithAgent(arg1, arg2, arg3, arg4, arg5, arg6, arg7) {
   return window['go']['main']['App']['ChatWithAgent'](arg1, arg2, arg3, arg4, arg5, arg6, arg7);
 }
 
+export function RunCodexDeepAnalysis(arg1, arg2, arg3) {
+  return window['go']['main']['App']['RunCodexDeepAnalysis'](arg1, arg2, arg3);
+}
+
 export function CheckDeviceBinding(arg1, arg2) {
   return window['go']['main']['App']['CheckDeviceBinding'](arg1, arg2);
 }

--- a/frontend/wailsjs/go/main/App.js
+++ b/frontend/wailsjs/go/main/App.js
@@ -6,6 +6,10 @@ export function AbortChatWithAgent() {
   return window['go']['main']['App']['AbortChatWithAgent']();
 }
 
+export function AbortCodexDeepAnalysis() {
+  return window['go']['main']['App']['AbortCodexDeepAnalysis']();
+}
+
 export function AbortSummaryStockNews() {
   return window['go']['main']['App']['AbortSummaryStockNews']();
 }

--- a/frontend/wailsjs/go/models.ts
+++ b/frontend/wailsjs/go/models.ts
@@ -10,8 +10,13 @@ export namespace data {
 	    baseUrl: string;
 	    apiKey: string;
 	    modelName: string;
+	    provider: string;
 	    maxTokens: number;
+	    maxInputTokens: number;
+	    maxOutputTokens: number;
 	    temperature: number;
+	    temperatureOpt?: number;
+	    reasoningEffort: string;
 	    timeOut: number;
 	    httpProxy: string;
 	    httpProxyEnabled: boolean;
@@ -31,8 +36,13 @@ export namespace data {
 	        this.baseUrl = source["baseUrl"];
 	        this.apiKey = source["apiKey"];
 	        this.modelName = source["modelName"];
+	        this.provider = source["provider"];
 	        this.maxTokens = source["maxTokens"];
+	        this.maxInputTokens = source["maxInputTokens"];
+	        this.maxOutputTokens = source["maxOutputTokens"];
 	        this.temperature = source["temperature"];
+	        this.temperatureOpt = source["temperatureOpt"];
+	        this.reasoningEffort = source["reasoningEffort"];
 	        this.timeOut = source["timeOut"];
 	        this.httpProxy = source["httpProxy"];
 	        this.httpProxyEnabled = source["httpProxyEnabled"];
@@ -3429,4 +3439,3 @@ export namespace models {
 	}
 
 }
-

--- a/main.go
+++ b/main.go
@@ -77,6 +77,12 @@ func main() {
 	data.SponsorDecryptKeyHex = BuildKey
 	data.SetAppIcon(icon)
 	db.Init("")
+	// AI configuration columns are read by the first settings render. Migrate
+	// this small table synchronously to avoid racing the asynchronous full schema
+	// migration below after an upgrade from the legacy max_tokens schema.
+	if err := db.Dao.AutoMigrate(&data.AIConfig{}); err != nil {
+		log.SugaredLogger.Fatalf("AI config migration failed: %v", err)
+	}
 	data.InitAnalyzeSentiment()
 	go AutoMigrate()
 


### PR DESCRIPTION
## What changed

- separate AI input-context and output-token budgets while preserving the legacy `maxTokens` fallback
- add provider-aware defaults for GPT-5.6 Sol and Grok 4.5
- map modern reasoning models to `reasoning_effort` and `max_completion_tokens`; retain legacy parameters for other OpenAI-compatible models
- trim oversized direct-API context without mutating callers, while preserving system prompts, the latest question, and assistant/tool-call pairs
- add configurable provider, reasoning effort, nullable temperature, input budget, output budget, and recommended profiles to the AI configuration UI
- add an explicit local `codex exec` deep-analysis action with cancellation, queue-aware timeout, an isolated temporary `CODEX_HOME`, and a read-only sandbox
- migrate the AI configuration table synchronously before the first settings render
- make malformed or missing sponsor payload/key data return errors instead of panicking in local builds
- document why the existing Chat Completions transport remains intentional and where a future Responses API adapter belongs

## Why

The legacy `MaxTokens` value controlled both input compression and generated output. Lower output limits could therefore discard useful context, while high values allowed unnecessarily large responses. Provider-specific reasoning semantics were also inconsistent between direct API and Agent paths, and local Codex jobs could not be cancelled while queued or running.

This change centralizes provider policy and input-budget enforcement. Direct API remains the default for streaming, tool calls, chat, and scheduled work; local Codex is an explicit deep-analysis path only.

## Recommended defaults

| Model | Input | Output | Reasoning | Temperature | Timeout |
| --- | ---: | ---: | --- | ---: | ---: |
| GPT-5.6 Sol | 96,000 | 16,384 | medium | omitted | 900 s |
| Grok 4.5 | 96,000 | 8,192 | medium | 0.2 | 600 s |

## Validation

- targeted policy, migration, context-budget, sponsor-safety, Agent request-body, and Codex cancellation tests pass
- real isolated `codex exec` with `gpt-5.6-sol`, `medium`, and read-only sandbox returned successfully
- isolated application database migration completed with `PRAGMA integrity_check = ok`
- GPT-5.6 Sol and Grok 4.5 both passed real streaming-answer smoke tests
- GPT-5.6 Sol and Grok 4.5 both completed a real `IsTradingDay` tool call and final answer
- runtime policy logs confirmed GPT: input 96,000, output 16,384, medium, temperature omitted, timeout 900 s
- runtime policy logs confirmed Grok: input 96,000, output 8,192, medium, temperature 0.2, timeout 600 s
- `go vet ./backend/codexcli ./backend/data ./backend/agent`
- `go build ./...`
- `npm run build`

The full `go test ./...` run still hits pre-existing environment-dependent failures: root tests call Wails runtime methods without a lifecycle context, `TestGetStockAiAgent` assumes a populated AI configuration, and `TestGetAllDataTools` uses an uninitialized GORM database. Remaining legacy network tests were stopped after prolonged inactivity. The focused suites covering this change pass.
