### PR TITLE
fix: 提升市场 AI 总结的容错能力

### DIFF
--- a/app.go
+++ b/app.go
@@ -2760,6 +2760,27 @@ func (a *App) GlobalStockIndexesReadable() string {
 	return data.NewMarketNewsApi().GlobalStockIndexesReadable(30)
 }
 
+func summaryStreamFailure(msg map[string]any) string {
+	fatal, _ := msg["fatal"].(bool)
+	codeZero := false
+	switch code := msg["code"].(type) {
+	case int:
+		codeZero = code == 0
+	case float64:
+		codeZero = code == 0
+	}
+	if !fatal && !codeZero {
+		return ""
+	}
+	if errText, ok := msg["error"].(string); ok && strings.TrimSpace(errText) != "" {
+		return errText
+	}
+	if content, ok := msg["content"].(string); ok && strings.TrimSpace(content) != "" {
+		return content
+	}
+	return "AI 分析未能正常完成"
+}
+
 func (a *App) SummaryStockNews(question string, aiConfigId int, sysPromptId *int, enableTools bool, think bool, eventName string, historyJSON string) {
 	ctx, cancel := context.WithCancel(a.ctx)
 
@@ -2799,7 +2820,11 @@ func (a *App) SummaryStockNews(question string, aiConfigId int, sysPromptId *int
 		msgs = data.NewDeepSeekOpenAi(ctx, aiConfigId).NewSummaryStockNewsStream(question, sysPromptId, think, history)
 	}
 
+	failureMessage := ""
 	for msg := range msgs {
+		if streamError := summaryStreamFailure(msg); streamError != "" {
+			failureMessage = streamError
+		}
 		runtime.EventsEmit(a.ctx, eventName, msg)
 	}
 
@@ -2807,6 +2832,13 @@ func (a *App) SummaryStockNews(question string, aiConfigId int, sysPromptId *int
 	a.summaryCancel = nil
 	a.summaryMu.Unlock()
 
+	if failureMessage != "" {
+		runtime.EventsEmit(a.ctx, eventName, map[string]any{
+			"status": "failed",
+			"error":  failureMessage,
+		})
+		return
+	}
 	runtime.EventsEmit(a.ctx, eventName, "DONE")
 }
 func (a *App) GetIndustryRank(sort string, cnt int) []any {

--- a/backend/agent/tools/data_tools_wrapper.go
+++ b/backend/agent/tools/data_tools_wrapper.go
@@ -2476,9 +2476,20 @@ func GetAllDataTools() []tool.BaseTool {
 			if yearMonth == "" {
 				yearMonth = time.Now().Format("2006-01")
 			}
-			calendarData := data.NewMarketNewsApi().InvestCalendar(yearMonth)
+			calendarResult, err := data.NewMarketNewsApi().InvestCalendarForAI(yearMonth)
+			if err != nil {
+				return "", err
+			}
+			calendarData, _ := calendarResult["items"].([]any)
 			if len(calendarData) == 0 {
 				return "当日暂无投资日历数据", nil
+			}
+			if calendarResult["source"] == "财联社投资日历" {
+				jsonBytes, marshalErr := json.Marshal(calendarResult)
+				if marshalErr != nil {
+					return "", marshalErr
+				}
+				return string(jsonBytes), nil
 			}
 			type calendarRow struct {
 				Date      string `md:"日期"`

--- a/backend/data/alert_darwin_api_test.go
+++ b/backend/data/alert_darwin_api_test.go
@@ -4,10 +4,9 @@
 package data
 
 import (
-	"go-stock/backend/logger"
 	"testing"
 
-	"github.com/go-toast/toast"
+	"github.com/stretchr/testify/require"
 )
 
 // @Author 2lovecode
@@ -15,18 +14,10 @@ import (
 // @Desc
 // -----------------------------------------------------------------------------------
 
-func TestAlert(t *testing.T) {
-	notification := toast.Notification{
-		AppID:    "go-stock",
-		Title:    "Hello, World!",
-		Message:  "This is a toast notification.",
-		Icon:     "../../build/appicon.png",
-		Duration: "short",
-		Audio:    toast.Default,
-	}
-	err := notification.Push()
-	if err != nil {
-		logger.SugaredLogger.Error(err)
-		return
-	}
+func TestNewAlertWindowsApiDarwin(t *testing.T) {
+	alert := NewAlertWindowsApi("go-stock", "Hello, World!", "This is a notification.", "../../build/appicon.png")
+
+	require.Equal(t, "go-stock", alert.AppID)
+	require.Equal(t, "Hello, World!", alert.Title)
+	require.Equal(t, "This is a notification.", alert.Content)
 }

--- a/backend/data/calendar_response.go
+++ b/backend/data/calendar_response.go
@@ -1,0 +1,68 @@
+package data
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+)
+
+type calendarFetcher func() ([]any, error)
+
+// decodeJSONArrayField decodes an array field from a third-party JSON response.
+// It deliberately treats a missing or null field as an error so callers never
+// need unsafe type assertions on partially successful business responses.
+func decodeJSONArrayField(body []byte, field string) ([]any, error) {
+	var response map[string]json.RawMessage
+	if err := json.Unmarshal(body, &response); err != nil {
+		return nil, fmt.Errorf("解析响应失败: %w", err)
+	}
+
+	raw, ok := response[field]
+	if !ok || len(raw) == 0 || bytes.Equal(bytes.TrimSpace(raw), []byte("null")) {
+		message := responseMessage(response)
+		if message == "" {
+			message = fmt.Sprintf("响应缺少有效字段 %q", field)
+		}
+		return nil, fmt.Errorf("第三方接口返回异常: %s", message)
+	}
+
+	var items []any
+	if err := json.Unmarshal(raw, &items); err != nil {
+		return nil, fmt.Errorf("字段 %q 不是数组: %w", field, err)
+	}
+	return items, nil
+}
+
+func responseMessage(response map[string]json.RawMessage) string {
+	for _, field := range []string{"msg", "message", "error"} {
+		raw, ok := response[field]
+		if !ok {
+			continue
+		}
+		var message string
+		if err := json.Unmarshal(raw, &message); err == nil && message != "" {
+			return message
+		}
+	}
+	return ""
+}
+
+func resolveInvestCalendar(primary, fallback calendarFetcher) (map[string]any, error) {
+	items, primaryErr := primary()
+	if primaryErr == nil {
+		return map[string]any{
+			"source": "韭研公社投资日历",
+			"items":  items,
+		}, nil
+	}
+
+	items, fallbackErr := fallback()
+	if fallbackErr == nil {
+		return map[string]any{
+			"source": "财联社投资日历",
+			"items":  items,
+		}, nil
+	}
+
+	return nil, fmt.Errorf("投资日历主接口失败: %v; 备用接口失败: %w", primaryErr, fallbackErr)
+}

--- a/backend/data/market_news_api.go
+++ b/backend/data/market_news_api.go
@@ -8,6 +8,7 @@ import (
 	"go-stock/backend/models"
 	"go-stock/backend/util"
 	"net/url"
+	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -1154,38 +1155,62 @@ func (m MarketNewsApi) HotTopic(size int) []any {
 }
 
 func (m MarketNewsApi) InvestCalendar(yearMonth string) []any {
+	items, err := m.InvestCalendarWithError(yearMonth)
+	if err != nil {
+		logger.SugaredLogger.Warnf("InvestCalendar unavailable: %s", err.Error())
+		return []any{}
+	}
+	return items
+}
+
+func (m MarketNewsApi) InvestCalendarWithError(yearMonth string) ([]any, error) {
 	if yearMonth == "" {
 		yearMonth = time.Now().Format("2006-01")
 	}
+	token := strings.TrimSpace(os.Getenv("GO_STOCK_JIUYANGONGSHE_TOKEN"))
+	if token == "" {
+		return nil, fmt.Errorf("未配置 GO_STOCK_JIUYANGONGSHE_TOKEN")
+	}
 
 	url := "https://app.jiuyangongshe.com/jystock-app/api/v1/timeline/list"
-	resp, err := SharedHTTPClient.SetTimeout(time.Duration(30)*time.Second).R().
+	request := SharedHTTPClient.SetTimeout(time.Duration(30)*time.Second).R().
 		SetHeader("Host", "app.jiuyangongshe.com").
 		SetHeader("Origin", "https://www.jiuyangongshe.com").
 		SetHeader("Referer", "https://www.jiuyangongshe.com/").
 		SetHeader("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:140.0) Gecko/20100101 Firefox/140.0").
 		SetHeader("Content-Type", "application/json").
-		SetHeader("token", "1cc6380a05c652b922b3d85124c85473").
+		SetHeader("token", token).
 		SetHeader("platform", "3").
-		SetHeader("Cookie", "SESSION=NDZkNDU2ODYtODEwYi00ZGZkLWEyY2ItNjgxYzY4ZWMzZDEy").
-		SetHeader("timestamp", strconv.FormatInt(time.Now().UnixMilli(), 10)).
+		SetHeader("timestamp", strconv.FormatInt(time.Now().UnixMilli(), 10))
+	if session := strings.TrimSpace(os.Getenv("GO_STOCK_JIUYANGONGSHE_SESSION")); session != "" {
+		request.SetHeader("Cookie", "SESSION="+session)
+	}
+	resp, err := request.
 		SetBody(map[string]string{
 			"date":  yearMonth,
 			"grade": "0",
 		}).
 		Post(url)
 	if err != nil {
-		logger.SugaredLogger.Errorf("InvestCalendar err:%s", err.Error())
-		return []any{}
+		return nil, fmt.Errorf("请求韭研公社投资日历失败: %w", err)
 	}
-	//logger.SugaredLogger.Infof("InvestCalendar:%s", resp.Body())
-	respMap := map[string]any{}
-	err = json.Unmarshal(resp.Body(), &respMap)
-	return respMap["data"].([]any)
+	if resp.IsError() {
+		return nil, fmt.Errorf("韭研公社投资日历 HTTP %d", resp.StatusCode())
+	}
+	return decodeJSONArrayField(resp.Body(), "data")
 
 }
 
 func (m MarketNewsApi) ClsCalendar() []any {
+	items, err := m.ClsCalendarWithError()
+	if err != nil {
+		logger.SugaredLogger.Warnf("ClsCalendar unavailable: %s", err.Error())
+		return []any{}
+	}
+	return items
+}
+
+func (m MarketNewsApi) ClsCalendarWithError() ([]any, error) {
 	url := "https://www.cls.cn/api/calendar/web/list?app=CailianpressWeb&flag=0&os=web&sv=8.4.6&type=0&sign=4b839750dc2f6b803d1c8ca00d2b40be"
 	resp, err := SharedHTTPClient.SetTimeout(time.Duration(30)*time.Second).R().
 		SetHeader("Host", "www.cls.cn").
@@ -1194,12 +1219,19 @@ func (m MarketNewsApi) ClsCalendar() []any {
 		SetHeader("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:140.0) Gecko/20100101 Firefox/140.0").
 		Get(url)
 	if err != nil {
-		logger.SugaredLogger.Errorf("ClsCalendar err:%s", err.Error())
-		return []any{}
+		return nil, fmt.Errorf("请求财联社投资日历失败: %w", err)
 	}
-	respMap := map[string]any{}
-	err = json.Unmarshal(resp.Body(), &respMap)
-	return respMap["data"].([]any)
+	if resp.IsError() {
+		return nil, fmt.Errorf("财联社投资日历 HTTP %d", resp.StatusCode())
+	}
+	return decodeJSONArrayField(resp.Body(), "data")
+}
+
+func (m MarketNewsApi) InvestCalendarForAI(yearMonth string) (map[string]any, error) {
+	return resolveInvestCalendar(
+		func() ([]any, error) { return m.InvestCalendarWithError(yearMonth) },
+		m.ClsCalendarWithError,
+	)
 }
 
 func (m MarketNewsApi) GetGDP() *models.GDPResp {

--- a/backend/data/market_news_calendar_test.go
+++ b/backend/data/market_news_calendar_test.go
@@ -1,0 +1,68 @@
+package data
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDecodeJSONArrayFieldRejectsBusinessErrorWithoutPanicking(t *testing.T) {
+	body := []byte(`{"errCode":"9","msg":"token无效，请重试","serverTime":1784769598}`)
+
+	items, err := decodeJSONArrayField(body, "data")
+
+	require.ErrorContains(t, err, "token无效，请重试")
+	require.Empty(t, items)
+}
+
+func TestDecodeJSONArrayFieldReturnsItems(t *testing.T) {
+	body := []byte(`{"code":200,"data":[{"title":"政策发布"}]}`)
+
+	items, err := decodeJSONArrayField(body, "data")
+
+	require.NoError(t, err)
+	require.Len(t, items, 1)
+}
+
+func TestDecodeJSONArrayFieldRejectsMalformedAndWrongShapeResponses(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+	}{
+		{name: "malformed json", body: `not-json`},
+		{name: "object instead of array", body: `{"data":{"title":"政策发布"}}`},
+		{name: "missing data", body: `{"code":200}`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			items, err := decodeJSONArrayField([]byte(tt.body), "data")
+
+			require.Error(t, err)
+			require.Empty(t, items)
+		})
+	}
+}
+
+func TestResolveInvestCalendarFallsBackToCLS(t *testing.T) {
+	result, err := resolveInvestCalendar(
+		func() ([]any, error) { return nil, errors.New("primary failed") },
+		func() ([]any, error) { return []any{map[string]any{"calendar_day": "2026-07-23"}}, nil },
+	)
+
+	require.NoError(t, err)
+	require.Equal(t, "财联社投资日历", result["source"])
+	require.Len(t, result["items"], 1)
+}
+
+func TestResolveInvestCalendarReturnsCombinedFailure(t *testing.T) {
+	result, err := resolveInvestCalendar(
+		func() ([]any, error) { return nil, errors.New("primary failed") },
+		func() ([]any, error) { return nil, errors.New("fallback failed") },
+	)
+
+	require.ErrorContains(t, err, "primary failed")
+	require.ErrorContains(t, err, "fallback failed")
+	require.Nil(t, result)
+}

--- a/backend/data/openai_stream.go
+++ b/backend/data/openai_stream.go
@@ -30,12 +30,17 @@ func (o *OpenAi) NewSummaryStockNewsStreamWithTools(userQuestion string, sysProm
 
 	go func() {
 		defer func() {
-			if err := recover(); err != nil {
-				logger.SugaredLogger.Errorf("NewSummaryStockNewsStream goroutine panic: %s", err)
+			if recovered := recover(); recovered != nil {
+				logger.SugaredLogger.Errorf("NewSummaryStockNewsStream goroutine panic: %v", recovered)
 				logger.SugaredLogger.Errorf("NewSummaryStockNewsStream goroutine panic context: model=%s timeout=%d maxTokens=%d", o.Model, o.TimeOut, o.MaxTokens)
+				ch <- map[string]any{
+					"code":  0,
+					"fatal": true,
+					"error": fmt.Sprintf("AI 分析过程中发生异常: %v", recovered),
+				}
 			}
+			close(ch)
 		}()
-		defer close(ch)
 
 		sysPrompt := ""
 		if sysPromptId == nil || *sysPromptId == 0 {
@@ -170,12 +175,17 @@ func (o *OpenAi) NewSummaryStockNewsStream(userQuestion string, sysPromptId *int
 
 	go func() {
 		defer func() {
-			if err := recover(); err != nil {
-				logger.SugaredLogger.Errorf("NewSummaryStockNewsStream goroutine  panic :%s", err)
+			if recovered := recover(); recovered != nil {
+				logger.SugaredLogger.Errorf("NewSummaryStockNewsStream goroutine panic: %v", recovered)
 				logger.SugaredLogger.Errorf("NewSummaryStockNewsStream goroutine panic context: model=%s baseUrl=%s", o.Model, o.BaseUrl)
+				ch <- map[string]any{
+					"code":  0,
+					"fatal": true,
+					"error": fmt.Sprintf("AI 分析过程中发生异常: %v", recovered),
+				}
 			}
+			close(ch)
 		}()
-		defer close(ch)
 
 		sysPrompt := ""
 		if sysPromptId == nil || *sysPromptId == 0 {

--- a/backend/data/openai_tool_safety_test.go
+++ b/backend/data/openai_tool_safety_test.go
@@ -1,0 +1,28 @@
+package data
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestExecuteToolHandlerSafelyConvertsPanicToError(t *testing.T) {
+	handler := func(_ *OpenAi, _ string, _ *ToolContext) error {
+		panic("calendar response shape changed")
+	}
+
+	err := executeToolHandlerSafely("GetInvestCalendar", handler, nil, `{}`, nil)
+
+	require.ErrorContains(t, err, "GetInvestCalendar")
+	require.ErrorContains(t, err, "calendar response shape changed")
+}
+
+func TestExecuteToolHandlerSafelyReturnsHandlerError(t *testing.T) {
+	expected := errors.New("handler failed")
+	handler := func(_ *OpenAi, _ string, _ *ToolContext) error { return expected }
+
+	err := executeToolHandlerSafely("Example", handler, nil, `{}`, nil)
+
+	require.ErrorIs(t, err, expected)
+}

--- a/backend/data/openai_tools.go
+++ b/backend/data/openai_tools.go
@@ -683,7 +683,8 @@ func AskAiWithToolsDepth(o *OpenAi, err error, messages []map[string]interface{}
 			}
 			funcArguments := call.Arguments.String()
 			if handler, ok := toolHandlers[call.Name]; ok {
-				if hErr := handler(o, funcArguments, &ToolContext{
+				messagesBefore := len(messages)
+				if hErr := executeToolHandlerSafely(call.Name, handler, o, funcArguments, &ToolContext{
 					Question:             question,
 					Messages:             &messages,
 					CurrentAIContent:     &currentAIContent,
@@ -697,10 +698,23 @@ func AskAiWithToolsDepth(o *OpenAi, err error, messages []map[string]interface{}
 					SystemPrompt:         extractSystemPrompt(&messages),
 				}); hErr != nil {
 					logger.SugaredLogger.Errorf("tool %s error: %s", call.Name, hErr.Error())
+					toolError := fmt.Sprintf("工具 %s 调用失败: %s。请使用其他可用数据继续完成分析，并明确说明数据缺失。", call.Name, hErr.Error())
+					if len(messages) == messagesBefore {
+						appendToolMessages(
+							&messages,
+							currentAIContent.String(),
+							reasoningContentText.String(),
+							call.ID,
+							call.Name,
+							funcArguments,
+							toolError,
+						)
+					}
 					ch <- map[string]any{
-						"code":     0,
-						"question": question,
-						"content":  hErr.Error(),
+						"code":              1,
+						"question":          question,
+						"tool_error":        hErr.Error(),
+						"reasoning_content": "\n" + toolError + "\n",
 					}
 				}
 				continue

--- a/backend/data/tool_agent_extra.go
+++ b/backend/data/tool_agent_extra.go
@@ -362,7 +362,10 @@ func handleGetInvestCalendar(o *OpenAi, funcArguments string, ctx *ToolContext) 
 	if yearMonth == "" {
 		yearMonth = time.Now().Format("2006-01")
 	}
-	res := NewMarketNewsApi().InvestCalendar(yearMonth)
+	res, err := NewMarketNewsApi().InvestCalendarForAI(yearMonth)
+	if err != nil {
+		return err
+	}
 	jsonBytes, _ := json.Marshal(res)
 	appendToolMessages(ctx.Messages, ctx.CurrentAIContent.String(), ctx.ReasoningContentText.String(), ctx.CurrentCallID, ctx.FuncName, funcArguments, string(jsonBytes))
 	return nil

--- a/backend/data/tool_registry.go
+++ b/backend/data/tool_registry.go
@@ -1,6 +1,7 @@
 package data
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/samber/lo"
@@ -23,6 +24,15 @@ type ToolContext struct {
 
 // ToolHandler 统一的工具处理函数签名
 type ToolHandler func(o *OpenAi, args string, ctx *ToolContext) error
+
+func executeToolHandlerSafely(name string, handler ToolHandler, o *OpenAi, args string, ctx *ToolContext) (err error) {
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			err = fmt.Errorf("工具 %s 执行异常: %v", name, recovered)
+		}
+	}()
+	return handler(o, args, ctx)
+}
 
 var toolHandlers = map[string]ToolHandler{}
 

--- a/frontend/src/components/market.vue
+++ b/frontend/src/components/market.vue
@@ -65,6 +65,7 @@ const theme = computed(() => {
   return darkTheme ? 'dark' : 'light'
 })
 const aiSummary = ref(``)
+const aiReasoning = ref(``)
 const aiSummaryTime = ref("")
 const modelName = ref("")
 const chatId = ref("")
@@ -261,6 +262,10 @@ function industryRank() {
 
 function reAiSummary() {
   aiSummary.value = ""
+  aiReasoning.value = ""
+  chatId.value = ""
+  modelName.value = ""
+  aiSummaryTime.value = ""
   summaryModal.value = true
   loading.value = true
   analysisStatus.value = "正在连接AI服务..."
@@ -270,6 +275,7 @@ function reAiSummary() {
 function getAiSummary() {
   summaryModal.value = true
   loading.value = true
+  aiReasoning.value = ""
   GetAIResponseResult("市场资讯").then(result => {
     loading.value = false
     if (result.content) {
@@ -289,6 +295,7 @@ function getAiSummary() {
     } else {
       aiSummaryTime.value = ""
       aiSummary.value = ""
+      aiReasoning.value = ""
       modelName.value = ""
       //SummaryStockNews(question.value, sysPromptId.value,enableTools.value)
     }
@@ -301,8 +308,42 @@ function updateTab(name) {
 }
 
 EventsOn("summaryStockNews", async (msg) => {
+  if (msg?.status === "failed") {
+    loading.value = false
+    analysisStatus.value = "分析失败"
+    message.destroyAll()
+    notify.error({
+      title: 'AI分析失败',
+      content: msg.error || 'AI分析未能正常完成，请稍后重试',
+      duration: 5000,
+    })
+    return
+  }
   if (msg === "DONE") {
-    await SaveAIResponseResult("市场资讯", "市场资讯", aiSummary.value, chatId.value, question.value,aiConfigId.value)
+    const finalReport = aiSummary.value.trim()
+    if (!finalReport) {
+      loading.value = false
+      analysisStatus.value = "分析失败"
+      message.destroyAll()
+      notify.error({
+        title: 'AI分析失败',
+        content: '模型未返回最终报告，本次结果不会保存',
+        duration: 5000,
+      })
+      return
+    }
+    try {
+      await SaveAIResponseResult("市场资讯", "市场资讯", finalReport, chatId.value, question.value,aiConfigId.value)
+    } catch (error) {
+      loading.value = false
+      analysisStatus.value = "保存失败"
+      notify.error({
+        title: 'AI报告保存失败',
+        content: error?.message || String(error),
+        duration: 5000,
+      })
+      return
+    }
     loading.value = false
     analysisStatus.value = "分析完成"
     message.destroyAll()
@@ -315,6 +356,11 @@ EventsOn("summaryStockNews", async (msg) => {
       analysisStatus.value = ""
     }, 3000)
   } else {
+    if (msg?.code === 0 || msg?.fatal) {
+      loading.value = false
+      analysisStatus.value = "分析失败"
+      return
+    }
     if (msg.chatId) {
       chatId.value = msg.chatId
     }
@@ -325,13 +371,15 @@ EventsOn("summaryStockNews", async (msg) => {
       if (!aiSummary.value) {
         analysisStatus.value = "AI正在分析中..."
       }
+    }
+    if (msg.content || msg.extraContent) {
       loading.value = false
     }
     if (msg.content) {
       aiSummary.value = aiSummary.value + msg.content
     }
     if (msg.reasoning_content) {
-      aiSummary.value = aiSummary.value + msg.reasoning_content
+      aiReasoning.value = aiReasoning.value + msg.reasoning_content
     }
     if (msg.extraContent) {
       aiSummary.value = aiSummary.value + msg.extraContent

--- a/summary_stream_test.go
+++ b/summary_stream_test.go
@@ -1,0 +1,22 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSummaryStreamFailureRecognizesFatalAndCodeZero(t *testing.T) {
+	require.Equal(t, "panic", summaryStreamFailure(map[string]any{
+		"fatal": true,
+		"error": "panic",
+	}))
+	require.Equal(t, "upstream failed", summaryStreamFailure(map[string]any{
+		"code":    0,
+		"content": "upstream failed",
+	}))
+	require.Empty(t, summaryStreamFailure(map[string]any{
+		"code":    1,
+		"content": "report",
+	}))
+}


### PR DESCRIPTION
## 变更摘要

- 安全解析投资日历响应；AI 工具调用在韭研公社接口不可用时自动降级到财联社日历
- 隔离单个工具的异常，避免一个数据源失败导致整次市场总结中断
- 传递流式处理的致命错误，不再无条件发送 `DONE`
- 将推理内容与最终报告分离，不再保存空白或失败的总结

## 问题根因

韭研公社日历接口使用了已经失效的硬编码 Token，并返回 `data: null`。客户端直接将 `data` 断言为 `[]any`，因而触发 panic。流式处理的恢复逻辑随后只关闭了通道，没有向上层报告失败；应用仍然发送 `DONE`，导致前端把残缺的推理和工具调用文本当作完整报告保存。

## 用户影响

当主要日历数据源不可用时，市场 AI 总结可以改用财联社日历继续执行。单个工具失败会作为可恢复信息返回给模型；真正的流式分析失败会明确显示错误，并且不会保存结果。模型产生的 `Finalizing...` 等推理内容也不会再混入保存的市场报告。

## 验证结果

- 投资日历解析、降级处理、工具异常隔离和终止状态相关测试通过
- 所有 Go 包的 `go test ./... -run '^$' -count=1` 编译检查通过
- `npm run build` 前端生产构建通过
- 财联社日历实时集成测试通过
- 使用生产数据库临时快照执行真实 `gpt-5.6-sol` 市场总结验收，79.5 秒完成并返回非空最终报告
- 正式数据库及当前运行中的 `bin/go-stock` 均未修改

仓库完整测试套件中仍存在与本次修改无关的既有失败，原因包括测试数据库缺少表、Wails runtime context 无效以及 GORM 未初始化。
