### PR TITLE
fix: honor proxy settings for Feishu model requests

### DIFF
--- a/backend/agent/chat_model_factory.go
+++ b/backend/agent/chat_model_factory.go
@@ -405,30 +405,53 @@ func buildChatModelHTTPClient(timeout time.Duration, extraHeaders, sessionId str
 	config := data.GetSettingConfig()
 	hasProxy := config != nil && config.HttpProxyEnabled && config.HttpProxy != ""
 
-	if !hasHeaders && !hasProxy {
-		return nil
-	}
-
-	var transport http.RoundTripper = http.DefaultTransport
-	if hasProxy {
-		proxyURL, err := url.Parse(config.HttpProxy)
-		if err != nil {
-			logger.SugaredLogger.Warnf("解析HTTP代理失败: %v", err)
-		} else {
-			transport = &http.Transport{Proxy: http.ProxyURL(proxyURL)}
+	// Always provide an explicit transport. Returning nil here lets the model SDK
+	// fall back to http.DefaultTransport, whose ProxyFromEnvironment behavior can
+	// silently route Feishu/agent requests through HTTP_PROXY or HTTPS_PROXY even
+	// when the application proxy is disabled.
+	configuredTransport, err := newChatModelTransport(hasProxy, func() string {
+		if config == nil {
+			return ""
 		}
+		return config.HttpProxy
+	}())
+	if err != nil {
+		logger.SugaredLogger.Warnf("解析HTTP代理失败: %v", err)
 	}
 
+	var roundTripper http.RoundTripper = configuredTransport
 	if hasHeaders {
-		transport = &headerInjectTransport{
-			base:      transport,
+		roundTripper = &headerInjectTransport{
+			base:      roundTripper,
 			headers:   headers,
 			sessionId: sessionId,
 		}
 	}
 
 	return &http.Client{
-		Transport: transport,
+		Transport: roundTripper,
 		Timeout:   timeout,
 	}
+}
+
+// newChatModelTransport clones the standard transport but clears its
+// environment-derived proxy. An application proxy is opt-in via settings.
+func newChatModelTransport(proxyEnabled bool, proxyURL string) (*http.Transport, error) {
+	base, ok := http.DefaultTransport.(*http.Transport)
+	if !ok {
+		base = &http.Transport{}
+	}
+	transport := base.Clone()
+	transport.Proxy = nil
+
+	if !proxyEnabled || strings.TrimSpace(proxyURL) == "" {
+		return transport, nil
+	}
+
+	parsed, err := url.Parse(proxyURL)
+	if err != nil {
+		return transport, err
+	}
+	transport.Proxy = http.ProxyURL(parsed)
+	return transport, nil
 }

--- a/backend/agent/chat_model_factory_proxy_test.go
+++ b/backend/agent/chat_model_factory_proxy_test.go
@@ -1,0 +1,48 @@
+package agent
+
+import (
+	"net/http"
+	"testing"
+)
+
+func TestNewChatModelTransportDisablesEnvironmentProxy(t *testing.T) {
+	transport, err := newChatModelTransport(false, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if transport.Proxy != nil {
+		t.Fatal("expected environment proxy to be disabled when app proxy is off")
+	}
+}
+
+func TestNewChatModelTransportUsesConfiguredProxy(t *testing.T) {
+	transport, err := newChatModelTransport(true, "http://127.0.0.1:8080")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if transport.Proxy == nil {
+		t.Fatal("expected configured proxy to be enabled")
+	}
+
+	req, err := http.NewRequest(http.MethodGet, "https://example.com", nil)
+	if err != nil {
+		t.Fatalf("create request: %v", err)
+	}
+	proxyURL, err := transport.Proxy(req)
+	if err != nil {
+		t.Fatalf("resolve proxy: %v", err)
+	}
+	if proxyURL.String() != "http://127.0.0.1:8080" {
+		t.Fatalf("unexpected proxy URL: %s", proxyURL)
+	}
+}
+
+func TestNewChatModelTransportRejectsInvalidProxy(t *testing.T) {
+	transport, err := newChatModelTransport(true, "://invalid")
+	if err == nil {
+		t.Fatal("expected invalid proxy URL to return an error")
+	}
+	if transport.Proxy != nil {
+		t.Fatal("invalid proxy URL must not install a proxy")
+	}
+}


### PR DESCRIPTION
## Summary

Fixes the Feishu model request path so it honors the configured proxy environment consistently with the other model transports.

Closes #172

## Verification

- go test -vet=off ./backend/agent -run TestNewChatModelTransport -count=1