### PR TITLE
fix(models): refresh Moonshot/Kimi builtin model list (K2.x + K3)

### DIFF
--- a/backend/agent/builtin_models.go
+++ b/backend/agent/builtin_models.go
@@ -114,17 +114,10 @@ var builtinContextWindow = map[string]int{
 	"kimi-k2.7-code":           256000,
 	"kimi-k2.7-code-highspeed": 256000,
 	"kimi-k2.6":                256000,
-	// 以下为已退役型号（调用返回 404），仅为兼容历史配置保留，不属于当前可用序列：
-	// 早期 K2 系列 2026-05-25 退役；kimi-k2.5 与 moonshot-v1 系列 2026-08-31 退役
-	"kimi-k2.5":              256000, // deprecated 2026-08-31
-	"kimi-k2-thinking":       256000, // deprecated 2026-05-25
-	"kimi-k2-thinking-turbo": 256000, // deprecated 2026-05-25
-	"kimi-k2-0905-preview":   256000, // deprecated 2026-05-25
-	"kimi-k2-0711-preview":   256000, // deprecated 2026-05-25
-	"kimi-k2-turbo-preview":  256000, // deprecated 2026-05-25
-	"moonshot-v1-8k":         8000,   // deprecated 2026-08-31
-	"moonshot-v1-32k":        32000,  // deprecated 2026-08-31
-	"moonshot-v1-128k":       128000, // deprecated 2026-08-31
+	// moonshot-v1 系列 2026-08-31 退役（调用返回 404），仅为兼容历史配置保留
+	"moonshot-v1-8k":   8000,   // deprecated 2026-08-31
+	"moonshot-v1-32k":  32000,  // deprecated 2026-08-31
+	"moonshot-v1-128k": 128000, // deprecated 2026-08-31
 
 	// ---- Qwen 系列 ----
 	"qwen-turbo":           1000000,
@@ -191,7 +184,7 @@ var builtinContextWindowPrefix = map[string]int{
 	"claude-3":       200000,
 	"glm-5":          200000,  // GLM-5/5.1（5.2 由精确匹配命中）
 	"kimi-k3":        1000000, // Kimi K3：1M 上下文（记十进制）
-	"kimi-k2":        256000,  // Kimi K2 系列兜底（仅限已知 K2 系，不推断未来型号）
+	"kimi-k2":        256000,  // Kimi K2 系列兜底（仅限 K2 系列）
 	"glm-4":          128000,
 	"chatglm":        8000,
 	"gemini-2.5-pro": 2000000, // Gemini 2.5 Pro：2M
@@ -303,13 +296,10 @@ var builtinMaxOutput = map[string]int{
 	"kimi-k2.7-code":           32768,
 	"kimi-k2.7-code-highspeed": 32768,
 	"kimi-k2.6":                32768,
-	// 以下为已退役型号，仅为兼容历史配置保留
-	"kimi-k2.5":              32768, // deprecated 2026-08-31
-	"kimi-k2-thinking":       32768, // deprecated 2026-05-25
-	"kimi-k2-thinking-turbo": 32768, // deprecated 2026-05-25
-	"moonshot-v1-8k":         8000,  // deprecated 2026-08-31
-	"moonshot-v1-32k":        8000,  // deprecated 2026-08-31
-	"moonshot-v1-128k":       8000,  // deprecated 2026-08-31
+	// moonshot-v1 系列 2026-08-31 退役，仅为兼容历史配置保留
+	"moonshot-v1-8k":   8000, // deprecated 2026-08-31
+	"moonshot-v1-32k":  8000, // deprecated 2026-08-31
+	"moonshot-v1-128k": 8000, // deprecated 2026-08-31
 
 	// ---- Qwen 系列 ----
 	"qwen-turbo":           8000,
@@ -358,7 +348,7 @@ var builtinMaxOutput = map[string]int{
 // builtinMaxOutputPrefix 前缀匹配的输出上限。
 var builtinMaxOutputPrefix = map[string]int{
 	"kimi-k3":        131072, // Kimi K3：官方默认 max_completion_tokens
-	"kimi-k2":        32768,  // Kimi K2 系列兜底（官方默认 max_tokens）
+	"kimi-k2":        32768,  // Kimi K2 系列兜底（仅限 K2 系列；官方默认 max_tokens）
 	"deepseek-v4":    384000, // DeepSeek V4：384K 输出
 	"deepseek":       8000,   // DeepSeek V3 及更早
 	"gpt-5.6":        32000,

--- a/backend/agent/builtin_models.go
+++ b/backend/agent/builtin_models.go
@@ -108,9 +108,21 @@ var builtinContextWindow = map[string]int{
 	// Gemini 2.5 Flash / 3 Flash / 3.1 Pro 均为 1M 上下文
 
 	// ---- Moonshot ----
-	"moonshot-v1-8k":   8000,
-	"moonshot-v1-32k":  32000,
-	"moonshot-v1-128k": 128000,
+	// Kimi K3：1M 上下文旗舰，多模态，reasoning low/high/max
+	"kimi-k3": 1048576,
+	// Kimi K2 系列均为 256K 上下文
+	"kimi-k2.7-code":           262144,
+	"kimi-k2.7-code-highspeed": 262144,
+	"kimi-k2.6":                262144,
+	"kimi-k2.5":                262144,
+	"kimi-k2-thinking":         262144,
+	"kimi-k2-thinking-turbo":   262144,
+	"kimi-k2-0905-preview":     262144,
+	"kimi-k2-0711-preview":     262144,
+	"kimi-k2-turbo-preview":    262144,
+	"moonshot-v1-8k":           8000,
+	"moonshot-v1-32k":          32000,
+	"moonshot-v1-128k":         128000,
 
 	// ---- Qwen 系列 ----
 	"qwen-turbo":           1000000,
@@ -175,7 +187,9 @@ var builtinContextWindowPrefix = map[string]int{
 	"claude-sonnet":  1000000, // 覆盖 sonnet-5 和 sonnet-4.x
 	"claude-fable":   1000000,
 	"claude-3":       200000,
-	"glm-5":          200000, // GLM-5/5.1（5.2 由精确匹配命中）
+	"glm-5":          200000,  // GLM-5/5.1（5.2 由精确匹配命中）
+	"kimi-k3":        1048576, // Kimi K3：1M 上下文
+	"kimi-":          262144,  // Kimi K2 系列及后续新型号兜底
 	"glm-4":          128000,
 	"chatglm":        8000,
 	"gemini-2.5-pro": 2000000, // Gemini 2.5 Pro：2M
@@ -282,9 +296,17 @@ var builtinMaxOutput = map[string]int{
 	"chatglm-turbo": 4000,
 
 	// ---- Moonshot ----
-	"moonshot-v1-8k":   8000,
-	"moonshot-v1-32k":  8000,
-	"moonshot-v1-128k": 8000,
+	"kimi-k3": 131072, // K3：128K 输出
+	// K2 系列输出上限与平台默认一致
+	"kimi-k2.7-code":           8000,
+	"kimi-k2.7-code-highspeed": 8000,
+	"kimi-k2.6":                8000,
+	"kimi-k2.5":                8000,
+	"kimi-k2-thinking":         8000,
+	"kimi-k2-thinking-turbo":   8000,
+	"moonshot-v1-8k":           8000,
+	"moonshot-v1-32k":          8000,
+	"moonshot-v1-128k":         8000,
 
 	// ---- Qwen 系列 ----
 	"qwen-turbo":           8000,
@@ -332,6 +354,8 @@ var builtinMaxOutput = map[string]int{
 
 // builtinMaxOutputPrefix 前缀匹配的输出上限。
 var builtinMaxOutputPrefix = map[string]int{
+	"kimi-k3":        131072, // Kimi K3：128K 输出
+	"kimi-":          8000,
 	"deepseek-v4":    384000, // DeepSeek V4：384K 输出
 	"deepseek":       8000,   // DeepSeek V3 及更早
 	"gpt-5.6":        32000,

--- a/backend/agent/builtin_models.go
+++ b/backend/agent/builtin_models.go
@@ -108,21 +108,23 @@ var builtinContextWindow = map[string]int{
 	// Gemini 2.5 Flash / 3 Flash / 3.1 Pro 均为 1M 上下文
 
 	// ---- Moonshot ----
-	// Kimi K3：1M 上下文旗舰，多模态，reasoning low/high/max
-	"kimi-k3": 1048576,
-	// Kimi K2 系列均为 256K 上下文
-	"kimi-k2.7-code":           262144,
-	"kimi-k2.7-code-highspeed": 262144,
-	"kimi-k2.6":                262144,
-	"kimi-k2.5":                262144,
-	"kimi-k2-thinking":         262144,
-	"kimi-k2-thinking-turbo":   262144,
-	"kimi-k2-0905-preview":     262144,
-	"kimi-k2-0711-preview":     262144,
-	"kimi-k2-turbo-preview":    262144,
-	"moonshot-v1-8k":           8000,
-	"moonshot-v1-32k":          32000,
-	"moonshot-v1-128k":         128000,
+	// Kimi K3：官方宣传 1M 上下文，按本文件约定记十进制；多模态，reasoning low/high/max
+	"kimi-k3": 1000000,
+	// Kimi K2.6 / K2.7 系列：官方 256K 上下文，记十进制
+	"kimi-k2.7-code":           256000,
+	"kimi-k2.7-code-highspeed": 256000,
+	"kimi-k2.6":                256000,
+	// 以下为已退役型号（调用返回 404），仅为兼容历史配置保留，不属于当前可用序列：
+	// 早期 K2 系列 2026-05-25 退役；kimi-k2.5 与 moonshot-v1 系列 2026-08-31 退役
+	"kimi-k2.5":              256000, // deprecated 2026-08-31
+	"kimi-k2-thinking":       256000, // deprecated 2026-05-25
+	"kimi-k2-thinking-turbo": 256000, // deprecated 2026-05-25
+	"kimi-k2-0905-preview":   256000, // deprecated 2026-05-25
+	"kimi-k2-0711-preview":   256000, // deprecated 2026-05-25
+	"kimi-k2-turbo-preview":  256000, // deprecated 2026-05-25
+	"moonshot-v1-8k":         8000,   // deprecated 2026-08-31
+	"moonshot-v1-32k":        32000,  // deprecated 2026-08-31
+	"moonshot-v1-128k":       128000, // deprecated 2026-08-31
 
 	// ---- Qwen 系列 ----
 	"qwen-turbo":           1000000,
@@ -188,8 +190,8 @@ var builtinContextWindowPrefix = map[string]int{
 	"claude-fable":   1000000,
 	"claude-3":       200000,
 	"glm-5":          200000,  // GLM-5/5.1（5.2 由精确匹配命中）
-	"kimi-k3":        1048576, // Kimi K3：1M 上下文
-	"kimi-":          262144,  // Kimi K2 系列及后续新型号兜底
+	"kimi-k3":        1000000, // Kimi K3：1M 上下文（记十进制）
+	"kimi-k2":        256000,  // Kimi K2 系列兜底（仅限已知 K2 系，不推断未来型号）
 	"glm-4":          128000,
 	"chatglm":        8000,
 	"gemini-2.5-pro": 2000000, // Gemini 2.5 Pro：2M
@@ -296,17 +298,18 @@ var builtinMaxOutput = map[string]int{
 	"chatglm-turbo": 4000,
 
 	// ---- Moonshot ----
-	"kimi-k3": 131072, // K3：128K 输出
-	// K2 系列输出上限与平台默认一致
-	"kimi-k2.7-code":           8000,
-	"kimi-k2.7-code-highspeed": 8000,
-	"kimi-k2.6":                8000,
-	"kimi-k2.5":                8000,
-	"kimi-k2-thinking":         8000,
-	"kimi-k2-thinking-turbo":   8000,
-	"moonshot-v1-8k":           8000,
-	"moonshot-v1-32k":          8000,
-	"moonshot-v1-128k":         8000,
+	"kimi-k3": 131072, // 官方默认 max_completion_tokens（默认值，非绝对上限；官方允许最高 1048576）
+	// K2.6 / K2.7 系列：官方默认 max_tokens = 32768
+	"kimi-k2.7-code":           32768,
+	"kimi-k2.7-code-highspeed": 32768,
+	"kimi-k2.6":                32768,
+	// 以下为已退役型号，仅为兼容历史配置保留
+	"kimi-k2.5":              32768, // deprecated 2026-08-31
+	"kimi-k2-thinking":       32768, // deprecated 2026-05-25
+	"kimi-k2-thinking-turbo": 32768, // deprecated 2026-05-25
+	"moonshot-v1-8k":         8000,  // deprecated 2026-08-31
+	"moonshot-v1-32k":        8000,  // deprecated 2026-08-31
+	"moonshot-v1-128k":       8000,  // deprecated 2026-08-31
 
 	// ---- Qwen 系列 ----
 	"qwen-turbo":           8000,
@@ -354,8 +357,8 @@ var builtinMaxOutput = map[string]int{
 
 // builtinMaxOutputPrefix 前缀匹配的输出上限。
 var builtinMaxOutputPrefix = map[string]int{
-	"kimi-k3":        131072, // Kimi K3：128K 输出
-	"kimi-":          8000,
+	"kimi-k3":        131072, // Kimi K3：官方默认 max_completion_tokens
+	"kimi-k2":        32768,  // Kimi K2 系列兜底（官方默认 max_tokens）
 	"deepseek-v4":    384000, // DeepSeek V4：384K 输出
 	"deepseek":       8000,   // DeepSeek V3 及更早
 	"gpt-5.6":        32000,

--- a/backend/agent/builtin_models_test.go
+++ b/backend/agent/builtin_models_test.go
@@ -1,0 +1,44 @@
+package agent
+
+import "testing"
+
+// TestBuiltinKimiModelMetadata 覆盖 Kimi 精确匹配、前缀兜底与未知型号行为，
+// 防止模型元数据表和前缀优先级被改坏。
+func TestBuiltinKimiModelMetadata(t *testing.T) {
+	ctxCases := []struct {
+		model string
+		want  int
+	}{
+		{"kimi-k3", 1000000},         // 精确匹配（十进制约定）
+		{"Kimi-K3", 1000000},         // 大小写不敏感
+		{"kimi-k2.7-code", 256000},   // 精确匹配
+		{"kimi-k2.6", 256000},        // 精确匹配
+		{"kimi-k2.9-future", 256000}, // 未知 K2 系走 kimi-k2 前缀兜底
+		{"kimi-k9", 0},               // 非已知系列不做推断
+		{"moonshot-v1-8k", 8000},     // 历史型号仍兼容
+		{"totally-unknown-model", 0}, // 未知返回 0
+	}
+	for _, c := range ctxCases {
+		if got := GetBuiltinModelContextWindow(c.model); got != c.want {
+			t.Errorf("GetBuiltinModelContextWindow(%q) = %d, want %d", c.model, got, c.want)
+		}
+	}
+
+	outCases := []struct {
+		model string
+		want  int
+	}{
+		{"kimi-k3", 131072},       // 官方默认 max_completion_tokens
+		{"kimi-k2.7-code", 32768}, // 官方默认 max_tokens
+		{"kimi-k2.7-code-highspeed", 32768},
+		{"kimi-k2.6", 32768},
+		{"kimi-k2.9-future", 32768}, // kimi-k2 前缀兜底
+		{"kimi-k9", 0},              // 非已知系列不做推断
+		{"totally-unknown-model", 0},
+	}
+	for _, c := range outCases {
+		if got := GetBuiltinModelMaxOutput(c.model); got != c.want {
+			t.Errorf("GetBuiltinModelMaxOutput(%q) = %d, want %d", c.model, got, c.want)
+		}
+	}
+}


### PR DESCRIPTION
## What

`backend/agent/builtin_models.go` only had `moonshot-v1-8k/32k/128k` from the v1 era. This PR adds token metadata for the **currently served** Kimi models — scope is token metadata only (see "Known gap" below).

**Context window** (recorded in decimal per this file's stated convention: marketing "1M/256K" → 1000000/256000)
- `kimi-k3`: 1000000 (multimodal, reasoning effort low/high/max)
- `kimi-k2.7-code(-highspeed)` / `kimi-k2.6`: 256000 (official K2.7 Code doc: 256K context)

**Max output**
- `kimi-k3`: 131072 — the official **default** max_completion_tokens (not an absolute cap; the platform allows up to 1048576)
- `kimi-k2.7-code(-highspeed)` / `kimi-k2.6`: 32768 — official default `max_tokens` (K2.7 Code doc: "Default to be 32k aka 32768")

**Prefix fallback** — limited to the K2/K3 families (`kimi-k3` → 1000000/131072, `kimi-k2` → 256000/32768). Unrelated future Kimi families such as K4 are not inferred and fall through to the unknown-model path, matching the repo's existing series-fallback pattern.

**Retired models** — newly-added retired K2 entries were dropped after review: their historical limits differ per model and across sources (e.g. `kimi-k2-0711-preview` is 131072/16384 in models.dev, not the blanket K2 values), so guessing per-model values was not worth the risk. The pre-existing `moonshot-v1-*` entries are kept and marked deprecated (retired 2026-08-31, calls return 404).

**Tests**: table-driven `builtin_models_test.go` covering exact matches, case-insensitivity, prefix fallback (incl. future K2 slugs), and unknown-model behavior. `gofmt` clean, `go build ./backend/agent/` and `go test -run TestBuiltinKimiModelMetadata` pass.

## Known gap (not addressed here)

The app's default `temperature=0.1` is sent on the generic OpenAI path, but Kimi models pin specific parameter values — K2.7 requires `temperature=1.0` (and fixed `top_p=0.95`, `n=1`, zero penalties; thinking always on), and K2.6/K3 have similar fixed-parameter requirements. Until the request path omits/overrides those fields for Kimi providers, this PR should be read as token-metadata groundwork, not full support for the current Kimi lineup.

## Sources

- Kimi K2.7 Code quickstart doc (256K context; default max_tokens 32768; fixed temperature/top_p/n/penalties)
- Kimi K3 pricing page + models.dev registry (K3 1M context; K2.x 256K context; k2-0711-preview historical 131072/16384)